### PR TITLE
feat: allow manual cart quantity entry

### DIFF
--- a/assets/cart-preview-sidebar.js
+++ b/assets/cart-preview-sidebar.js
@@ -136,8 +136,19 @@
           if (plusButton) newQty = currentQty + 1;
           if (minusButton) newQty = currentQty - 1;
           if (removeButton) newQty = 0;
-          if (typeof newQty !== 'undefined' && key) this.updateQuantity(key, newQty);
+        if (typeof newQty !== 'undefined' && key) this.updateQuantity(key, newQty);
         }
+      });
+
+      document.body.addEventListener('change', (event) => {
+        const input = event.target.closest(selectors.qtyValue);
+        if (!input) return;
+        const cartItem = input.closest(selectors.cartItem);
+        if (!cartItem) return;
+        event.preventDefault();
+        const key = cartItem.dataset.lineKey;
+        const newQty = parseInt(input.value, 10);
+        if (key && !isNaN(newQty)) this.updateQuantity(key, newQty);
       });
     }
 

--- a/assets/custom.css
+++ b/assets/custom.css
@@ -625,8 +625,17 @@ ol.product-grid {
 .cart-drawer__quantity-value, .cart-sidebar__quantity-value {
   font-size: 0.95rem !important; font-weight: 600 !important; min-width: 32px !important; height: 100% !important;
   text-align: center !important; color: var(--brand-text) !important; background-color: #fff !important;
+  border: none !important;
   border-left: 1px solid #e9ecef !important; border-right: 1px solid #e9ecef !important;
   padding: 0 4px !important; display: flex !important; align-items: center !important; justify-content: center !important;
+  -moz-appearance: textfield !important;
+}
+.cart-drawer__quantity-value::-webkit-outer-spin-button,
+.cart-drawer__quantity-value::-webkit-inner-spin-button,
+.cart-sidebar__quantity-value::-webkit-outer-spin-button,
+.cart-sidebar__quantity-value::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
 }
 .cart-drawer__remove-btn, .cart-sidebar__remove-btn {
   grid-column: 3 / 4; align-self: center; display: flex !important; align-items: center !important;

--- a/snippets/cart-item-list.liquid
+++ b/snippets/cart-item-list.liquid
@@ -81,7 +81,14 @@ endif
               <div class="{{ class_prefix }}__item-actions">
                 <div class="{{ class_prefix }}__quantity-selector">
                   <button type="button" class="{{ class_prefix }}__quantity-btn" data-action="minus" aria-label="Decrease quantity">－</button>
-                  <span class="{{ class_prefix }}__quantity-value" aria-live="polite">{{ item.quantity }}</span>
+                  <input
+                    type="number"
+                    class="{{ class_prefix }}__quantity-value"
+                    value="{{ item.quantity }}"
+                    min="0"
+                    inputmode="numeric"
+                    aria-label="Quantity"
+                  >
                   <button type="button" class="{{ class_prefix }}__quantity-btn" data-action="plus" aria-label="Increase quantity">＋</button>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- replace quantity display span with number input
- style drawer and sidebar quantity input
- update cart manager to handle manual quantity changes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b9c73fc0832fa6907e15b4e67767