### PR TITLE
fix: restore quantity input styling and manual updates

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -1056,7 +1056,26 @@ ol.product-grid {
 }
 .integrated-quantity__button:hover { background-color: rgba(0, 0, 0, 0.1) !important; }
 .integrated-quantity__text { font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif !important; font-weight: 700 !important; pointer-events: none !important; flex-grow: 1; text-align: center; font-size: 1rem !important; }
-.integrated-quantity__input { position: absolute !important; opacity: 0 !important; pointer-events: none !important; }
+.integrated-quantity__input {
+  position: absolute !important;
+  top: 0;
+  left: 42px;
+  width: calc(100% - 84px);
+  height: 100%;
+  opacity: 0 !important;
+  pointer-events: auto !important;
+  background: transparent !important;
+  border: none !important;
+  color: inherit !important;
+  font: inherit !important;
+  text-align: center;
+  -moz-appearance: textfield;
+}
+.integrated-quantity__input::-webkit-outer-spin-button,
+.integrated-quantity__input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
 
 /* ---- Unchanged Helper and Fallback Styles ---- */
 .product-form--quick-add.is-loading .product-card__add-btn { color: transparent !important; }

--- a/assets/product-card.js
+++ b/assets/product-card.js
@@ -39,6 +39,8 @@ class ProductForm extends HTMLElement {
     this.addButton.addEventListener('click', this.onPlusClick.bind(this));
     this.plusButton.addEventListener('click', this.onPlusClick.bind(this));
     this.minusButton.addEventListener('click', this.onMinusClick.bind(this));
+    this.quantityInput.addEventListener('input', this.onQuantityInput.bind(this));
+    this.quantityInput.addEventListener('change', this.onQuantityChange.bind(this));
   }
 
   renderState() {
@@ -72,6 +74,15 @@ class ProductForm extends HTMLElement {
 
     const newQuantity = currentQuantity - 1;
     this.quantityInput.value = newQuantity;
+    this.setLoading(true);
+    this.debouncedUpdateCart();
+  }
+
+  onQuantityInput() {
+    this.renderState();
+  }
+
+  onQuantityChange() {
     this.setLoading(true);
     this.debouncedUpdateCart();
   }


### PR DESCRIPTION
## Summary
- style quantity inputs to match previous appearance while allowing manual edits
- update quick add product form to react to typed quantities

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5bbbe62f4832fa1460383e39d99a5