### PR TITLE
fix: constrain cart item actions width

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -604,6 +604,7 @@ ol.product-grid {
 }
 .cart-drawer__item-actions, .cart-sidebar__item-actions {
   display: flex !important; align-items: center !important; gap: 0.5rem !important; order: 1;
+  flex: 0 0 auto !important; width: fit-content !important;
 }
 .cart-drawer__properties, .cart-sidebar__properties {
   list-style: none; padding: 0; margin: 0.5rem 0 0; font-size: 0.8rem; line-height: 1.4;


### PR DESCRIPTION
## Summary
- limit cart drawer and sidebar action areas to fit content instead of stretching

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5bdba2aac832fbe9b2c222ef762d9