### PR TITLE
Fix meal plan hero overflow on mobile

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -2834,9 +2834,16 @@ body.quick-view-open {
 
 .meal-plan-hero-grid {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 420px;
-  gap: 3.5rem;
+  grid-template-columns: 1fr;
+  gap: 2.5rem;
   align-items: start;
+}
+
+@media (min-width: 1024px) {
+  .meal-plan-hero-grid {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 420px);
+    gap: 3.5rem;
+  }
 }
 
 /* Left Column: Info */
@@ -2885,6 +2892,10 @@ body.quick-view-open {
 /* Right Column: Form */
 .meal-plan-hero__form {
   padding-top: 0.25rem;
+}
+
+.meal-plan-form-card {
+  width: 100%;
 }
 
 .meal-plan-form__options {
@@ -3029,10 +3040,6 @@ body.quick-view-open {
 
 /* Responsive */
 @media (max-width: 1024px) {
-  .meal-plan-hero-grid {
-    grid-template-columns: 1fr;
-    gap: 2.5rem;
-  }
   .meal-plan-hero-container {
     padding: 2rem;
   }

--- a/sections/product-main-recharge.liquid
+++ b/sections/product-main-recharge.liquid
@@ -324,7 +324,7 @@ customElements.define('product-form-controller', ProductFormController);
   .meal-plan-quantity-callout.is-updating { animation: qty-flash 400ms ease-in-out; }
 
   /* --- Form Card --- */
-  .meal-plan-form-card { background: var(--color-surface); border-radius: var(--radius-lg); border: 1px solid var(--color-border); box-shadow: var(--shadow-md); padding: 1.5rem; }
+  .meal-plan-form-card { background: var(--color-surface); border-radius: var(--radius-lg); border: 1px solid var(--color-border); box-shadow: var(--shadow-md); padding: 1.5rem; width: 100%; }
   @media (min-width: 768px) { .meal-plan-form-card { padding: 2rem; } }
   .product-form-recharge { display: flex; flex-direction: column; gap: 1.5rem; }
   .form-step__label { display: flex; align-items: center; gap: 0.75rem; font-size: 1rem; font-weight: 600; margin-bottom: 0.75rem; }


### PR DESCRIPTION
## Summary
- prevent hero layout from exceeding viewport on small screens
- ensure meal plan form card stretches to container width

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68a752a4ad4c832fa52f7ec9c2bc8988