### PR TITLE
Fix meal plan hero grid width on mobile

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -2839,6 +2839,10 @@ body.quick-view-open {
   align-items: start;
 }
 
+.meal-plan-hero-grid > * {
+  min-width: 0;
+}
+
 @media (min-width: 1024px) {
   .meal-plan-hero-grid {
     grid-template-columns: minmax(0, 1fr) minmax(0, 420px);

--- a/sections/product-main-recharge.liquid
+++ b/sections/product-main-recharge.liquid
@@ -295,6 +295,7 @@ customElements.define('product-form-controller', ProductFormController);
   /* --- Main Layout & Info Column --- */
   .meal-plan-hero-container { margin-block: 2rem 4rem; }
   .meal-plan-hero-grid { display: grid; grid-template-columns: 1fr; gap: 2.5rem; align-items: flex-start; }
+  .meal-plan-hero-grid > * { min-width: 0; }
   @media (min-width: 990px) {
     .meal-plan-hero-grid { grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr); gap: 4rem; }
     .meal-plan-hero__form { position: sticky; top: 2rem; }


### PR DESCRIPTION
## Summary
- ensure meal-plan hero grid children shrink within container on mobile
- apply same min-width rule in product recharge section

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7575c52f8832f93c7468bc05ac3d4