### PR TITLE
Add Protein Popcorn BOGO upsell module

### DIFF
--- a/assets/addons-popcorn-bogo.js
+++ b/assets/addons-popcorn-bogo.js
@@ -1,0 +1,162 @@
+/* =====================================================================
+   Protein Popcorn BOGO module for Add-ons page
+   ===================================================================== */
+(function(){
+  document.addEventListener('DOMContentLoaded', function(){
+    const container = document.querySelector('[data-pp-bogo]');
+    if (!container) return;
+
+    const params = new URLSearchParams(window.location.search);
+    const devMode = params.get('pp_bogo_dev') === '1';
+
+    const defaultConfig = {
+      enabled: false,
+      endText: 'Ends Tuesday',
+      flavors: [
+        { label: 'Sample Savory', variantId: '1111111111' },
+        { label: 'Sample BBQ', variantId: '2222222222' }
+      ]
+    };
+    const config = Object.assign({}, defaultConfig, window.ppBogoConfig || {});
+    if ((!config.flavors || config.flavors.length === 0)) {
+      if (devMode) {
+        config.flavors = defaultConfig.flavors;
+      } else {
+        container.classList.add('hidden');
+        return;
+      }
+    }
+
+    const flavorSelect = container.querySelector('[data-pp-bogo-flavor]');
+    const endEl = container.querySelector('[data-pp-bogo-end]');
+    const addBtn = container.querySelector('[data-pp-bogo-add]');
+
+    // populate flavors
+    const availabilityPromises = [];
+    flavorSelect.innerHTML = '';
+    (config.flavors || []).forEach(f => {
+      const opt = document.createElement('option');
+      opt.value = f.variantId;
+      opt.textContent = f.label;
+      opt.disabled = true;
+      flavorSelect.appendChild(opt);
+      availabilityPromises.push(
+        checkAvailability(f.variantId).then(avail => {
+          if (avail) {
+            opt.disabled = false;
+          } else {
+            opt.textContent += ' (Unavailable)';
+          }
+        })
+      );
+    });
+
+    Promise.allSettled(availabilityPromises).then(() => {
+      const firstEnabled = Array.from(flavorSelect.options).find(o => !o.disabled);
+      if (firstEnabled) {
+        flavorSelect.value = firstEnabled.value;
+      } else if (!devMode) {
+        container.classList.add('hidden');
+      }
+      updateBtnState();
+    });
+
+    endEl.textContent = config.endText || 'Ends Tuesday';
+
+    flavorSelect.addEventListener('change', updateBtnState);
+    function updateBtnState(){
+      const option = flavorSelect.options[flavorSelect.selectedIndex];
+      addBtn.disabled = !option || option.disabled;
+    }
+
+    function isMeal(item){
+      const type = String(item.product_type || '').toLowerCase();
+      const handle = String(item.handle || '').toLowerCase();
+      // Exclude clearly non-meal categories only
+      const nonMealTypes = ['peanut butter','protein popcorn','seasoning','beverage','options_hidden_product'];
+      if (nonMealTypes.includes(type)) return false;
+      // Everything else (including meal plans) is counted; multiplier handles 12/24 parsing
+      return true;
+    }
+    function mealMultiplier(item){
+      if (item.properties && item.properties._meals_per_unit){
+        const n = parseInt(item.properties._meals_per_unit,10);
+        if(!isNaN(n) && n>0) return n;
+      }
+      const sources = [item.variant_title,item.title,item.sku]
+        .filter(Boolean)
+        .map(s => String(s).toLowerCase());
+      for (const src of sources){
+        // catches "12 Meal", "12-Meal", "24 meals"
+        const m = src.match(/(\d+)\s*[- ]*\s*meal(s)?\b/);
+        if (m){
+          const n = parseInt(m[1],10);
+          if(!isNaN(n) && n>0) return n;
+        }
+      }
+      return 1;
+    }
+    function mealCount(cart){
+      return (cart.items || []).reduce((count,item)=>{
+        if(!isMeal(item)) return count;
+        return count + item.quantity * mealMultiplier(item);
+      },0);
+    }
+    function fetchCart(){
+      return fetch('/cart.js', {credentials:'same-origin'}).then(r=>r.json());
+    }
+
+    async function evaluate(){
+      try{
+        const cart = await fetchCart();
+        const count = mealCount(cart);
+        const eligible = count >= 14;
+        if (eligible || devMode){
+          container.classList.remove('hidden');
+        } else {
+          container.classList.add('hidden');
+        }
+      } catch(e) {
+        console.error('PP BOGO eval failed', e);
+      }
+    }
+
+    evaluate();
+    document.addEventListener('cart:updated', evaluate);
+
+    addBtn.addEventListener('click', async () => {
+      const selected = flavorSelect.value;
+      if (!selected) return;
+
+      try {
+        if (!devMode){
+          const cart = await fetchCart();
+          if (mealCount(cart) < 14){
+            container.classList.add('hidden');
+            return;
+          }
+        }
+        addBtn.disabled = true;
+        const res = await fetch('/cart/add.js', {
+          method:'POST',
+          headers:{'Content-Type':'application/json'},
+          body: JSON.stringify({ id: selected, quantity:1 })
+        });
+        if (!res.ok) throw new Error('Add to cart failed');
+        const newCart = await fetchCart();
+        document.dispatchEvent(new CustomEvent('cart:updated', { detail:{ cart:newCart } }));
+      } catch(e){
+        console.error('PP BOGO add failed', e);
+      } finally {
+        addBtn.disabled = false;
+      }
+    });
+
+    function checkAvailability(id){
+      return fetch(`/variants/${id}.json`)
+        .then(r => r.json())
+        .then(data => data && data.variant && data.variant.available)
+        .catch(()=>false);
+    }
+  });
+})();

--- a/assets/custom.css
+++ b/assets/custom.css
@@ -3210,3 +3210,24 @@ body.quick-view-open {
   padding: 0 !important;        /* borders already provide separation */
   box-sizing: border-box !important;
 }
+
+/* Protein Popcorn BOGO card styles */
+.addon-card__note {
+  margin-top: 0.5rem;
+  font-size: 0.9rem;
+  color: #6c757d;
+}
+.addon-card__urgency {
+  margin-top: 0.5rem;
+  font-size: 0.85rem;
+  color: #dc3545;
+}
+.addon-card--pp-bogo .addon-card__options {
+  margin-top: 1rem;
+}
+.pp-bogo-preview-badge {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  color: #dc3545;
+  margin-bottom: 0.25rem;
+}

--- a/sections/template--addons.liquid
+++ b/sections/template--addons.liquid
@@ -29,6 +29,7 @@
     assign fallback_product_3 = all_products['butter-herb']
     assign free_delivery_target = settings.free_delivery_threshold | default: 21
     assign remaining_placeholder = '{remaining}'
+    assign pp_bogo_blocks = section.blocks | where: 'type', 'pp_bogo_flavor'
   -%}
 
 <div class="addons-page-wrapper" data-free-delivery-target="{{ free_delivery_target }}">
@@ -83,6 +84,7 @@
 
 
     <div class="addons-grid">
+      {% render 'addons-pp-bogo', section: section, flavor_blocks: pp_bogo_blocks %}
       {%- comment -%} CARD FOR SLOT 1 {%- endcomment -%}
       {%- if slot1_block and slot1_block.settings.product != blank -%}
         {% render 'addons-card', product_obj: slot1_block.settings.product, card_id: 'slot-1', collection_handle: slot1_block.settings.collection_handle, card_description_points: slot1_block.settings.card_description_points, slot: 'slot-1' %}
@@ -344,11 +346,25 @@
   });
 </script>
 {% endif %}
-
+<script src="{{ 'addons-popcorn-bogo.js' | asset_url }}" defer></script>
 
 {% schema %}
 {
   "name": "Add-Ons Page Section",
+  "settings": [
+    {
+      "type": "checkbox",
+      "id": "enable_pp_bogo",
+      "label": "Enable Protein Popcorn BOGO",
+      "default": false
+    },
+    {
+      "type": "text",
+      "id": "pp_bogo_end_text",
+      "label": "End date text",
+      "default": "Ends Tuesday"
+    }
+  ],
   "max_blocks": 50,
   "blocks": [
     {
@@ -385,6 +401,14 @@
           "label": "Benefit Points",
           "info": "List key benefits, separated by a pipe character (|). Example: Point one|Point two|Point three"
         }
+      ]
+    },
+    {
+      "type": "pp_bogo_flavor",
+      "name": "BOGO Flavor",
+      "settings": [
+        { "type": "text", "id": "label", "label": "Flavor label" },
+        { "type": "text", "id": "variant_id", "label": "Recharge bundle VARIANT ID (Shopify)" }
       ]
     }
   ],

--- a/snippets/addons-pp-bogo.liquid
+++ b/snippets/addons-pp-bogo.liquid
@@ -1,0 +1,48 @@
+{%- comment -%}
+  Protein Popcorn BOGO upsell card for add-ons page
+{%- endcomment -%}
+{%- assign dev_flag = request.params.pp_bogo_dev -%}
+{%- assign preview_mode = dev_flag == '1' -%}
+{%- assign enabled = section.settings.enable_pp_bogo -%}
+{%- assign has_blocks = flavor_blocks and flavor_blocks.size > 0 -%}
+{%- if enabled or preview_mode -%}
+<div class="addon-card-v2 addon-card--pp-bogo hidden" data-pp-bogo>
+  <div class="addon-card__body">
+    {%- if preview_mode -%}
+    <div class="pp-bogo-preview-badge">Preview</div>
+    {%- endif -%}
+    <h3 class="addon-card__title">BOGO Protein Popcorn — Savory 4-Pack</h3>
+    <p class="addon-card__note">Qualify with any 14+ meals. Limited time.</p>
+    <div class="addon-card__options">
+      <div class="addon-card__option-group">
+        <label for="pp-bogo-flavor">Flavor</label>
+        <select id="pp-bogo-flavor" data-pp-bogo-flavor>
+          {%- if has_blocks -%}
+            {%- for block in flavor_blocks -%}
+              <option value="{{ block.settings.variant_id }}">{{ block.settings.label }}</option>
+            {%- endfor -%}
+          {%- endif -%}
+        </select>
+      </div>
+    </div>
+  </div>
+  <div class="addon-card__footer">
+    <button type="button" class="btn addon-card__add-btn" data-pp-bogo-add>Add BOGO to Order</button>
+    <p class="addon-card__urgency" data-pp-bogo-end>{{ section.settings.pp_bogo_end_text | default: 'Ends Tuesday' }}</p>
+  </div>
+</div>
+{%- if enabled or has_blocks or section.settings.pp_bogo_end_text != blank -%}
+<script>
+  window.ppBogoConfig = window.ppBogoConfig || {};
+  window.ppBogoConfig.enabled = {{ enabled | json }};
+  window.ppBogoConfig.endText = {{ section.settings.pp_bogo_end_text | default: 'Ends Tuesday' | json }};
+  window.ppBogoConfig.flavors = [
+    {%- if has_blocks -%}
+      {%- for block in flavor_blocks -%}
+        { label: {{ block.settings.label | json }}, variantId: {{ block.settings.variant_id | json }} }{%- unless forloop.last -%},{%- endunless -%}
+      {%- endfor -%}
+    {%- endif -%}
+  ];
+</script>
+{%- endif -%}
+{%- endif -%}


### PR DESCRIPTION
## Summary
- Count meal plans toward BOGO eligibility and parse 12- or 24-meal quantities
- Use Shopify variant IDs for flavor mappings and availability checks with dev fallback when no flavors
- Auto-select first available flavor and hide module when no options remain

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a773e07f74832fb967fe48ffb72c56