### PR TITLE
Adjust mobile padding for product pages

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -271,9 +271,10 @@ ol.product-grid {
   .collection-page__layout { grid-template-columns: 1fr; }
   .collection-page__sidebar { display: none; }
   body.template-collection .collection-page__main { padding: 0; }
-  body.template-product .collection-page__main { padding: 0; }
-  body.template-product .collection-page__layout { padding: 0 1.5rem 2rem 1.5rem; }
+  body.template-product .collection-page__main { padding: 0; border-right: none; }
+  body.template-product .collection-page__layout { padding: 0 0 2rem; }
   body.template-collection .collection-header { padding-left: 1rem; padding-right: 1rem; margin: 0; }
+  body.template-product .collection-header { padding-left: 1rem; padding-right: 1rem; margin: 0; }
   body.template-collection ol.product-grid { padding: 1.25rem 1rem 0 1rem; }
   .desktop-filter-toggle { display: none !important; }
   body.collection-menu-open .mobile-controls-popover { display: none !important; }


### PR DESCRIPTION
## Summary
- remove excess padding around product headers and main container on mobile
- strip right border and side padding from product layouts for cleaner mobile view

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a77fbb3c30832fbfd042a818f70e3e