### PR TITLE
Add gift product support to BOGO widget

### DIFF
--- a/assets/addons-popcorn-bogo.js
+++ b/assets/addons-popcorn-bogo.js
@@ -7,17 +7,27 @@
     if (!container) return;
 
     const params = new URLSearchParams(window.location.search);
-    const devMode = params.get('pp_bogo_dev') === '1';
+    const devMode = params.get('bogo_dev') === '1' || params.get('pp_bogo_dev') === '1';
+
+    function debug(){
+      if (!devMode) return;
+      const args = Array.from(arguments);
+      args.unshift('[PP BOGO]');
+      console.log.apply(console, args);
+    }
 
     const defaultConfig = {
       enabled: false,
       endText: 'Ends Tuesday',
+      giftEnabled: false,
+      giftVariantId: null,
       flavors: [
         { label: 'Sample Savory', variantId: '1111111111' },
         { label: 'Sample BBQ', variantId: '2222222222' }
       ]
     };
     const config = Object.assign({}, defaultConfig, window.ppBogoConfig || {});
+    debug('config', config);
     if ((!config.flavors || config.flavors.length === 0)) {
       if (devMode) {
         config.flavors = defaultConfig.flavors;
@@ -106,16 +116,64 @@
       return fetch('/cart.js', {credentials:'same-origin'}).then(r=>r.json());
     }
 
+    async function syncGift(cart, eligible){
+      if (!config.giftEnabled || !config.giftVariantId) { debug('skip gift: not configured'); return; }
+      const items = cart.items || [];
+      const giftId = String(config.giftVariantId);
+      const giftLine = items.find(i => String(i.variant_id) === giftId);
+      const hasBogo = items.some(i => (config.flavors || []).some(f => String(f.variantId) === String(i.variant_id)));
+      debug('syncGift', {hasBogo, giftLine, eligible});
+
+      try {
+        if (hasBogo && eligible){
+          if (!giftLine){
+            debug('adding gift');
+            await fetch('/cart/add.js', {
+              method:'POST',
+              headers:{'Content-Type':'application/json'},
+              body: JSON.stringify({ id: giftId, quantity:1, properties:{ _bogo_gift:'1' } })
+            });
+            const newCart = await fetchCart();
+            document.dispatchEvent(new CustomEvent('cart:updated', { detail:{ cart:newCart } }));
+          } else if (giftLine.quantity > 1){
+            debug('reducing gift quantity');
+            const lineIndex = items.findIndex(i => String(i.key) === String(giftLine.key)) + 1;
+            await fetch('/cart/change.js', {
+              method:'POST',
+              headers:{'Content-Type':'application/json'},
+              body: JSON.stringify({ line: lineIndex, quantity:1 })
+            });
+            const newCart = await fetchCart();
+            document.dispatchEvent(new CustomEvent('cart:updated', { detail:{ cart:newCart } }));
+          }
+        } else if (giftLine){
+          debug('removing gift');
+          const lineIndex = items.findIndex(i => String(i.key) === String(giftLine.key)) + 1;
+          await fetch('/cart/change.js', {
+            method:'POST',
+            headers:{'Content-Type':'application/json'},
+            body: JSON.stringify({ line: lineIndex, quantity:0 })
+          });
+          const newCart = await fetchCart();
+          document.dispatchEvent(new CustomEvent('cart:updated', { detail:{ cart:newCart } }));
+        }
+      } catch(err){
+        console.error('PP BOGO gift sync failed', err);
+      }
+    }
+
     async function evaluate(){
       try{
         const cart = await fetchCart();
         const count = mealCount(cart);
         const eligible = count >= 14;
+        debug('evaluate', {count, eligible});
         if (eligible || devMode){
           container.classList.remove('hidden');
         } else {
           container.classList.add('hidden');
         }
+        await syncGift(cart, eligible);
       } catch(e) {
         console.error('PP BOGO eval failed', e);
       }

--- a/assets/custom.css
+++ b/assets/custom.css
@@ -3232,3 +3232,15 @@ body.quick-view-open {
   color: #dc3545;
   margin-bottom: 0.25rem;
 }
+
+/* Static quantity for BOGO gift items */
+.cart-sidebar__quantity-selector--static,
+.cart-drawer__quantity-selector--static {
+  justify-content: center;
+  pointer-events: none;
+}
+.cart-sidebar__quantity-selector--static .cart-sidebar__quantity-value,
+.cart-drawer__quantity-selector--static .cart-drawer__quantity-value {
+  border: none;
+  padding: 0;
+}

--- a/sections/template--addons.liquid
+++ b/sections/template--addons.liquid
@@ -363,6 +363,23 @@
       "id": "pp_bogo_end_text",
       "label": "End date text",
       "default": "Ends Tuesday"
+    },
+    {
+      "type": "checkbox",
+      "id": "enable_pp_bogo_gift",
+      "label": "Enable free gift",
+      "default": false
+    },
+    {
+      "type": "product",
+      "id": "pp_bogo_gift_product",
+      "label": "Gift product"
+    },
+    {
+      "type": "text",
+      "id": "pp_bogo_gift_variant_id",
+      "label": "Gift variant ID",
+      "info": "Single variant to add as free gift"
     }
   ],
   "max_blocks": 50,

--- a/snippets/addons-pp-bogo.liquid
+++ b/snippets/addons-pp-bogo.liquid
@@ -1,7 +1,7 @@
 {%- comment -%}
   Protein Popcorn BOGO upsell card for add-ons page
 {%- endcomment -%}
-{%- assign dev_flag = request.params.pp_bogo_dev -%}
+{%- assign dev_flag = request.params.bogo_dev | default: request.params.pp_bogo_dev -%}
 {%- assign preview_mode = dev_flag == '1' -%}
 {%- assign enabled = section.settings.enable_pp_bogo -%}
 {%- assign has_blocks = flavor_blocks and flavor_blocks.size > 0 -%}
@@ -32,10 +32,16 @@
   </div>
 </div>
 {%- if enabled or has_blocks or section.settings.pp_bogo_end_text != blank -%}
+{%- assign gift_variant_id = section.settings.pp_bogo_gift_variant_id -%}
+{%- if gift_variant_id == blank and section.settings.pp_bogo_gift_product and section.settings.pp_bogo_gift_product.variants_count == 1 -%}
+  {%- assign gift_variant_id = section.settings.pp_bogo_gift_product.variants.first.id -%}
+{%- endif -%}
 <script>
   window.ppBogoConfig = window.ppBogoConfig || {};
   window.ppBogoConfig.enabled = {{ enabled | json }};
   window.ppBogoConfig.endText = {{ section.settings.pp_bogo_end_text | default: 'Ends Tuesday' | json }};
+  window.ppBogoConfig.giftEnabled = {{ section.settings.enable_pp_bogo_gift | json }};
+  window.ppBogoConfig.giftVariantId = {{ gift_variant_id | json }};
   window.ppBogoConfig.flavors = [
     {%- if has_blocks -%}
       {%- for block in flavor_blocks -%}

--- a/snippets/cart-item-list.liquid
+++ b/snippets/cart-item-list.liquid
@@ -57,6 +57,7 @@ endif
           endif
 
           assign line_item_price = item.final_line_price
+          assign is_bogo_gift = item.properties._bogo_gift
 
           if is_custom_meal
             for hidden_item in cart.items
@@ -79,7 +80,8 @@ endif
             <div class="{{ class_prefix }}__item-meta">
               <span class="{{ class_prefix }}__item-price">{{ line_item_price | money }}</span>
               <div class="{{ class_prefix }}__item-actions">
-                <div class="{{ class_prefix }}__quantity-selector">
+                <div class="{{ class_prefix }}__quantity-selector{% if is_bogo_gift %} {{ class_prefix }}__quantity-selector--static{% endif %}">
+                  {% unless is_bogo_gift %}
                   <button type="button" class="{{ class_prefix }}__quantity-btn" data-action="minus" aria-label="Decrease quantity">－</button>
                   <input
                     type="number"
@@ -90,6 +92,9 @@ endif
                     aria-label="Quantity"
                   >
                   <button type="button" class="{{ class_prefix }}__quantity-btn" data-action="plus" aria-label="Increase quantity">＋</button>
+                  {% else %}
+                  <span class="{{ class_prefix }}__quantity-value">{{ item.quantity }}</span>
+                  {% endunless %}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- extend BOGO widget schema with gift product, variant, and enable toggle
- automatically sync a free gift with BOGO items and add dev logging
- hide quantity controls on gift line items and style static display
- handle gift eligibility and preview param edge cases

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a86a2dce54832fa9ac169bf34561c6