### PR TITLE
Add minimal footer to recharge meal plan product

### DIFF
--- a/sections/product-main-recharge.liquid
+++ b/sections/product-main-recharge.liquid
@@ -191,6 +191,8 @@
   <script type="application/json" data-included-meals-json>{%- if included_meals != blank -%}{{ included_meals | map: 'title' | json }}{%- else -%}[]{%- endif -%}</script>
 </product-form-controller>
 
+{%- render 'footer-minimal-ordering' -%}
+
 {% comment %} ==================================================================================== {% endcomment %}
 {% comment %} SCRIPT: MODIFIED - Removed injection logic and fixed update logic. {% endcomment %}
 {% comment %} ==================================================================================== {% endcomment %}


### PR DESCRIPTION
## Summary
- render `footer-minimal-ordering` in `product-main-recharge` so Recharge meal plan template matches other products

## Testing
- `theme-check` *(fails: command not found)*
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9a131c64832fb9160c13b2788ca3