### PR TITLE
Make meal plan hero section span full width

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -2836,6 +2836,20 @@ body.quick-view-open {
   margin-bottom: 4rem;
 }
 
+/* Make hero container span full width on Recharge meal plan pages */
+product-form-controller.meal-plan-premium-layout .meal-plan-hero-container {
+  margin-left: -1.5rem;
+  margin-right: -1.5rem;
+  border-radius: 0;
+}
+
+@media (max-width: 991px) {
+  product-form-controller.meal-plan-premium-layout .meal-plan-hero-container {
+    margin-left: 0;
+    margin-right: 0;
+  }
+}
+
 .meal-plan-hero-grid {
   display: grid;
   grid-template-columns: minmax(0, 1fr);


### PR DESCRIPTION
## Summary
- override hero container margins on recharge meal-plan pages to span edge-to-edge
- reset margins on small screens to preserve layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acc36e14ac832f86862b2cb1cc1543