### PR TITLE
Use two-column layout on Meal Plans page

### DIFF
--- a/layout/product-shell.liquid
+++ b/layout/product-shell.liquid
@@ -133,12 +133,15 @@
 	{% if template == 'index' %}
   		<link rel="preload" href="{{ 'theme-index.min.css' | asset_url }}" as="style">
 		{{ 'theme-index.min.css' | asset_url | stylesheet_tag }}
-	{% elsif template.name == 'collection' %}
-	    <link rel="preload" href="{{ 'theme-collection.min.css' | asset_url }}" as="style">
-	    {{ 'theme-collection.min.css' | asset_url | stylesheet_tag }}
-	{% elsif template == 'list-collections' %}
-	    <link rel="preload" href="{{ 'theme-collection-list.min.css' | asset_url }}" as="style">
-	    {{ 'theme-collection-list.min.css' | asset_url | stylesheet_tag }}
+        {% elsif template.name == 'collection' %}
+            <link rel="preload" href="{{ 'theme-collection.min.css' | asset_url }}" as="style">
+            {{ 'theme-collection.min.css' | asset_url | stylesheet_tag }}
+        {% elsif template.suffix == 'meal-plans' %}
+            <link rel="preload" href="{{ 'theme-collection.min.css' | asset_url }}" as="style">
+            {{ 'theme-collection.min.css' | asset_url | stylesheet_tag }}
+        {% elsif template == 'list-collections' %}
+            <link rel="preload" href="{{ 'theme-collection-list.min.css' | asset_url }}" as="style">
+            {{ 'theme-collection-list.min.css' | asset_url | stylesheet_tag }}
         {% elsif template.name contains 'product' %}
                 <link rel="preload" href="{{ 'theme-product.min.css' | asset_url }}" as="style">
                 {{ 'theme-product.min.css' | asset_url | stylesheet_tag }}
@@ -240,7 +243,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 			{% unless template.name contains 'balanced' %}{% section 'announcement-bar' %}{% endunless %}
 			
                         {%- comment -%} LOGIC: Render the collection-style header on collection and product templates only. {%- endcomment -%}
-                        {% if template.name contains 'collection' or template.name contains 'product' %}
+                        {% if template.name contains 'collection' or template.name contains 'product' or template.suffix == 'meal-plans' %}
                           {% section 'header-collections' %}
                         {% else %}
                           {% section 'header' %}
@@ -258,7 +261,9 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
                                        product content area, ensuring a consistent user experience.
                                   <!-- ======================================================================= -->
                                 {%- endcomment -%}
-                                {% render 'product-local-nav' %}
+                                {% if template.name contains 'product' %}
+                                  {% render 'product-local-nav' %}
+                                {% endif %}
 
                                 {%- if request.path contains 'loop_subscriptions/bundle' or request.path contains 'loop_subscriptions/customer' -%}
                                   {% render 'loop_loader' %}

--- a/templates/page.meal-plans.json
+++ b/templates/page.meal-plans.json
@@ -6,8 +6,9 @@
  * or related systems. Please exercise caution as any changes
  * made to this file may be overwritten.
  * ------------------------------------------------------------
- */
+*/
 {
+  "layout": "product-shell",
   "sections": {
     "meal_plan_header": {
       "type": "custom-meal-plan-header",


### PR DESCRIPTION
## Summary
- Render Meal Plans page with `product-shell` layout to show cart sidebar
- Load collection styles and funnel header for the Meal Plans template
- Only render product local nav on product templates

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acd25bbedc832f8455fb53c1566d2f