### PR TITLE
Add collection header and footer tweaks for meal plans page

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -266,6 +266,8 @@ ol.product-grid {
 .grid-view-toggle:hover { color: #495057; }
 .grid-view-toggle.is-active { background-color: #ffffff; color: var(--brand-text); box-shadow: 0 1px 3px rgba(0,0,0,0.08); }
 
+body.template-suffix--meal-plans .collection-page__main { padding-left: 0; padding-right: 0; }
+
 /* RESPONSIVE & MOBILE OVERRIDES */
 @media (max-width: 991px) {
   .collection-page__layout { grid-template-columns: 1fr; }

--- a/layout/product-shell.liquid
+++ b/layout/product-shell.liquid
@@ -281,7 +281,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
                         </main>
           
             {% unless template contains 'balanced' %}
-              {% if template.name == 'cart' %}
+              {% if template.name == 'cart' or template.suffix == 'meal-plans' %}
                 {% section 'footer-minimal-ordering' %}
               {% elsif template.name contains 'collection' or template.name contains 'product' %}
                 {%- comment -%} Footer is rendered inside the collection or product template {%- endcomment -%}

--- a/sections/meal-plans-collection-header.liquid
+++ b/sections/meal-plans-collection-header.liquid
@@ -1,0 +1,204 @@
+<div class="collection-header">
+  <div class="collection-selector" id="CollectionSelector" aria-expanded="false">
+    <button class="collection-selector__toggle" type="button" aria-haspopup="true" aria-controls="CollectionMenu">
+      <span class="collection-header__title">Meal Plans</span>
+      <svg class="collection-selector__icon" viewBox="0 0 10 6" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+    </button>
+    <div class="collection-selector__overlay"></div>
+    <nav id="CollectionMenu" class="collection-selector__menu" role="navigation" aria-label="Product Categories">
+      <div class="collection-selector__menu-content-wrapper">
+        <div class="collection-selector__menu-main">
+          <div class="collection-selector__mobile-header">
+            <span class="collection-selector__mobile-title">Choose a Category</span>
+            <button class="collection-selector__mobile-close-btn" aria-label="Close menu">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="24" height="24"><path d="M18.3 5.71a.996.996 0 0 0-1.41 0L12 10.59 7.11 5.7A.996.996 0 1 0 5.7 7.11L10.59 12 5.7 16.89a.996.996 0 1 0 1.41 1.41L12 13.41l4.89 4.89a.996.996 0 1 0 1.41-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"></path></svg>
+            </button>
+          </div>
+          <button class="collection-selector__menu-main-trigger" data-target-panel="panel-meals" data-title="Shop Meals">
+            <span class="trigger-content">
+              <span class="trigger-title">Shop Meals</span>
+              <span class="trigger-subtitle">Signature, Custom & Bulk Prep</span>
+            </span>
+          </button>
+          <button class="collection-selector__menu-main-trigger" data-target-panel="panel-meal-plans" data-title="Meal Plans">
+            <span class="trigger-content">
+              <span class="trigger-title">Meal Plans</span>
+              <span class="trigger-subtitle">Goal-Focused • 12 or 24 Meals</span>
+            </span>
+          </button>
+          <button class="collection-selector__menu-main-trigger" data-target-panel="panel-snacks" data-title="Snacks">
+            <span class="trigger-content">
+              <span class="trigger-title">Snacks</span>
+              <span class="trigger-subtitle">Protein Popcorn & More</span>
+            </span>
+          </button>
+          <button class="collection-selector__menu-main-trigger" data-target-panel="panel-extras" data-title="Extras">
+            <span class="trigger-content">
+              <span class="trigger-title">Extras</span>
+              <span class="trigger-subtitle">Upgrade Your Order</span>
+            </span>
+          </button>
+        </div>
+        <div class="collection-selector__menu-sub-panels">
+          <div class="collection-selector__mobile-header">
+            <button class="collection-selector__mobile-back-btn" aria-label="Back to main menu">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" width="20" height="20"><path fill-rule="evenodd" d="M12.79 5.23a.75.75 0 01-.02 1.06L8.832 10l3.938 3.71a.75.75 0 11-1.04 1.08l-4.5-4.25a.75.75 0 010-1.08l4.5-4.25a.75.75 0 011.06.02z" clip-rule="evenodd" /></svg>
+              <span>Back</span>
+            </button>
+            <span class="collection-selector__mobile-title" data-panel-title></span>
+            <button class="collection-selector__mobile-close-btn" aria-label="Close menu">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="24" height="24"><path d="M18.3 5.71a.996.996 0 0 0-1.41 0L12 10.59 7.11 5.7A.996.996 0 1 0 5.7 7.11L10.59 12 5.7 16.89a.996.996 0 1 0 1.41 1.41L12 13.41l4.89 4.89a.996.996 0 1 0 1.41-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"></path></svg>
+            </button>
+          </div>
+          <div id="panel-meals" class="collection-selector__menu-sub-panel">
+            <h3 class="collection-selector__menu-header">Meals</h3>
+            <ul>
+              <li><a href="/collections/signature-menu" role="menuitem">Signature Meals</a></li>
+              <li><a href="/products/custom-meals" role="menuitem">Custom Meals</a></li>
+              <li><a href="/products/custom-breakfast" role="menuitem">Custom Breakfast</a></li>
+              <li><a href="/collections/bulk-items" role="menuitem">Bulk Items</a></li>
+            </ul>
+          </div>
+          <div id="panel-meal-plans" class="collection-selector__menu-sub-panel">
+            <h3 class="collection-selector__menu-header">Goal-Focused Meal Plans</h3>
+            <ul>
+              <li><a href="/products/build-your-own-meal-plan" role="menuitem">Build Your Own</a></li>
+              <li><a href="/products/icon-meal-plan" role="menuitem">The ICON Plan</a></li>
+              <li><a href="/products/extreme-protein-meal-plan" role="menuitem">Extreme Protein</a></li>
+              <li><a href="/products/get-lean-meal-plan" role="menuitem">Get Lean</a></li>
+              <li><a href="/products/lean-lifter-meal-plan" role="menuitem">Lean Lifter</a></li>
+              <li><a href="/products/keto-meal-plan" role="menuitem">Keto</a></li>
+            </ul>
+          </div>
+          <div id="panel-snacks" class="collection-selector__menu-sub-panel">
+            <h3 class="collection-selector__menu-header">Snacks</h3>
+            <ul>
+              <li><a href="/collections/proteinpopcorn" role="menuitem">Protein Popcorn</a></li>
+              <li><a href="/collections/butters" role="menuitem">Protein Butters</a></li>
+            </ul>
+          </div>
+          <div id="panel-extras" class="collection-selector__menu-sub-panel">
+            <h3 class="collection-selector__menu-header">Extras</h3>
+            <ul>
+              <li><a href="/collections/proteincoffee" role="menuitem">Protein Coffee</a></li>
+              <li><a href="/collections/seasonings" role="menuitem">Seasonings</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </nav>
+  </div>
+</div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  const collectionSelector = document.getElementById('CollectionSelector');
+  if (collectionSelector) {
+    const toggleButton = collectionSelector.querySelector('.collection-selector__toggle');
+    const menu = collectionSelector.querySelector('#CollectionMenu');
+    const mainTriggers = menu.querySelectorAll('.collection-selector__menu-main-trigger');
+    const subPanels = menu.querySelectorAll('.collection-selector__menu-sub-panel');
+    const mobileCloseBtns = menu.querySelectorAll('.collection-selector__mobile-close-btn');
+    const mobileBackBtn = menu.querySelector('.collection-selector__mobile-back-btn');
+    const mobilePanelTitle = menu.querySelector('[data-panel-title]');
+    const overlay = collectionSelector.querySelector('.collection-selector__overlay');
+    let isMobile = window.innerWidth <= 991;
+
+    const openMenu = () => {
+      collectionSelector.setAttribute('aria-expanded', 'true');
+      if (isMobile) {
+        document.body.style.overflow = 'hidden';
+      }
+    };
+
+    const closeMenu = () => {
+      collectionSelector.setAttribute('aria-expanded', 'false');
+      if (isMobile) {
+        document.body.style.overflow = '';
+        menu.classList.remove('is-sub-menu-active');
+        subPanels.forEach(p => p.classList.remove('is-active'));
+        mainTriggers.forEach(t => t.classList.remove('is-active'));
+      }
+    };
+
+    const toggleMenu = () => {
+      const isOpen = collectionSelector.getAttribute('aria-expanded') === 'true';
+      isOpen ? closeMenu() : openMenu();
+    };
+
+    const activatePanel = (panelId, triggerEl) => {
+      mainTriggers.forEach(t => t.classList.remove('is-active'));
+      subPanels.forEach(p => p.classList.remove('is-active'));
+      if (triggerEl) triggerEl.classList.add('is-active');
+      const targetPanel = document.getElementById(panelId);
+      if (targetPanel) {
+        targetPanel.classList.add('is-active');
+      }
+    };
+
+    toggleButton.addEventListener('click', (e) => {
+      e.stopPropagation();
+      toggleMenu();
+    });
+
+    mainTriggers.forEach(trigger => {
+      const panelId = trigger.dataset.targetPanel;
+      if (isMobile) {
+        trigger.addEventListener('click', () => {
+          const title = trigger.dataset.title || trigger.querySelector('.trigger-title').textContent.trim();
+          if (mobilePanelTitle) mobilePanelTitle.textContent = title;
+          activatePanel(panelId, trigger);
+          menu.classList.add('is-sub-menu-active');
+        });
+      } else {
+        trigger.addEventListener('mouseenter', () => {
+          activatePanel(panelId, trigger);
+        });
+      }
+    });
+
+    if (!isMobile && mainTriggers.length > 0) {
+      activatePanel(mainTriggers[0].dataset.targetPanel, mainTriggers[0]);
+    }
+
+    if (mobileBackBtn) {
+      mobileBackBtn.addEventListener('click', () => {
+        menu.classList.remove('is-sub-menu-active');
+      });
+    }
+
+    if (mobileCloseBtns.length) {
+      mobileCloseBtns.forEach(btn => btn.addEventListener('click', closeMenu));
+    }
+
+    document.addEventListener('click', (e) => {
+      if (!collectionSelector.contains(e.target)) {
+        closeMenu();
+      }
+    });
+    if (overlay) {
+      overlay.addEventListener('click', closeMenu);
+    }
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && collectionSelector.getAttribute('aria-expanded') === 'true') {
+        closeMenu();
+      }
+    });
+
+    window.addEventListener('resize', () => {
+      isMobile = window.innerWidth <= 991;
+      if (!isMobile) closeMenu();
+    });
+  }
+});
+</script>
+
+{% schema %}
+{
+  "name": "Meal Plans Collection Header",
+  "class": "meal-plans-collection-header",
+  "settings": []
+}
+{% endschema %}

--- a/templates/page.meal-plans.json
+++ b/templates/page.meal-plans.json
@@ -10,6 +10,10 @@
 {
   "layout": "product-shell",
   "sections": {
+    "collection_header": {
+      "type": "meal-plans-collection-header",
+      "settings": {}
+    },
     "meal_plan_header": {
       "type": "custom-meal-plan-header",
       "settings": {
@@ -146,6 +150,7 @@
     }
   },
   "order": [
+    "collection_header",
     "meal_plan_header",
     "meal_plan_grid"
   ]


### PR DESCRIPTION
## Summary
- Add collection-style header and menu for meal plans page
- Remove side padding specific to meal plans layout
- Use minimal footer on meal plans page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acd4ee7e78832f817cde9e7c06832f