### PR TITLE
Fix meal plans collection selector alignment

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -268,6 +268,7 @@ ol.product-grid {
 
 body.template-suffix--meal-plans .collection-page__main { padding-left: 0; padding-right: 0; }
 body.template-suffix--meal-plans .collection-header { padding-left: 1rem; padding-right: 1rem; margin: 0; }
+body.template-suffix--meal-plans .collection-selector__toggle { padding-left: 0; }
 
 /* RESPONSIVE & MOBILE OVERRIDES */
 @media (max-width: 991px) {


### PR DESCRIPTION
## Summary
- remove left padding from collection selector toggle on meal plans page to align label

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ada4361a60832fa82b82129da54116