### PR TITLE
Allow custom display title for meal plan template

### DIFF
--- a/sections/product-main-recharge.liquid
+++ b/sections/product-main-recharge.liquid
@@ -51,7 +51,14 @@
 
       <div class="meal-plan-hero__info">
         <div class="meal-plan-hero__header">
-          <h1 class="meal-plan-hero__title">{{ product.title }}</h1>
+          {%- assign display_title = product.metafields.custom.display_title | strip -%}
+          <h1 class="meal-plan-hero__title">
+            {%- if display_title != blank -%}
+              {{- display_title | escape -}}
+            {%- else -%}
+              {{- product.title | escape -}}
+            {%- endif -%}
+          </h1>
           {%- if hero_hook != blank -%}
             <p class="meal-plan-hero__hook">{{ hero_hook }}</p>
           {%- endif -%}


### PR DESCRIPTION
## Summary
- support optional product `custom.display_title` metafield
- fall back to normal product title when metafield is absent or blank

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npx @shopify/theme-check@latest` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68add1cfe280832f9561c85c0ff442c6