### PR TITLE
Add meal plan promo breadcrumb with global controls

### DIFF
--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -1,2292 +1,2345 @@
 [
-    {
-        "name": "theme_info",
-        "theme_name": "Fresh",
-        "theme_author": "Eight",
-        "theme_version": "31.0.4",
-        "theme_documentation_url": "https://support.weareeight.com/hc/en-us/categories/360003660797-Fresh",
-        "theme_support_url": "https://support.weareeight.com/hc/en-us/requests/new"
+  {
+    "name": "theme_info",
+    "theme_name": "Fresh",
+    "theme_author": "Eight",
+    "theme_version": "31.0.4",
+    "theme_documentation_url": "https://support.weareeight.com/hc/en-us/categories/360003660797-Fresh",
+    "theme_support_url": "https://support.weareeight.com/hc/en-us/requests/new"
+  },
+  {
+    "name": {
+      "en": "Colors",
+      "de": "Farben",
+      "es": "Colores",
+      "fr": "Couleurs",
+      "pt-PT": "Cores"
     },
-    {
-        "name": {
-            "en": "Colors",
-            "de": "Farben",
-            "es": "Colores",
-            "fr": "Couleurs",
-            "pt-PT": "Cores"
+    "settings": [
+      {
+        "type": "header",
+        "content": {
+          "en": "General",
+          "de": "Allgemeines",
+          "es": "General",
+          "fr": "Général",
+          "pt-PT": "Geral"
+        }
+      },
+      {
+        "type": "color",
+        "id": "font-color",
+        "label": {
+          "en": "Text",
+          "de": "Text",
+          "es": "Texto",
+          "fr": "Texte",
+          "pt-PT": "Texto"
         },
-        "settings": [
-            {
-                "type": "header",
-                "content": {
-                    "en": "General",
-                    "de": "Allgemeines",
-                    "es": "General",
-                    "fr": "Général",
-                    "pt-PT": "Geral"
-                }
-            },
-            {
-                "type": "color",
-                "id": "font-color",
-                "label": {
-                    "en": "Text",
-                    "de": "Text",
-                    "es": "Texto",
-                    "fr": "Texte",
-                    "pt-PT": "Texto"
-                },
-                "default": "#333333"
-            },
-            {
-                "type": "color",
-                "id": "link-color",
-                "label": {
-                    "en": "Link",
-                    "de": "Link",
-                    "es": "Enlace",
-                    "fr": "Lien",
-                    "pt-PT": "Ligação"
-                },
-                "default": "#333333"
-            },
-            {
-                "type": "color",
-                "id": "active-link-color",
-                "label": {
-                    "en": "Active link",
-                    "fr": "Lien actif",
-                    "de": "Aktiver Link",
-                    "es": "Enlace activo",
-                    "pt-PT": "Ligação ativa"
-                },
-                "default": "#333333"
-            },
-            {
-                "type": "color",
-                "id": "bg_color",
-                "label": {
-                    "en": "Background",
-                    "de": "Hintergrund",
-                    "es": "Fondo",
-                    "fr": "Contexte général",
-                    "pt-PT": "Fundo"
-                },
-                "default": "#ffffff"
-            },
-            {
-                "type": "color",
-                "id": "border-color",
-                "label": {
-                    "en": "Borders",
-                    "de": "Borders",
-                    "es": "Bordes",
-                    "fr": "Bordures",
-                    "pt-PT": "Margens"
-                },
-                "default": "#BEBEBE"
-            },
-            {
-                "type": "header",
-                "content": {
-                    "en": "Header",
-                    "de": "Überschrift",
-                    "es": "Encabezado",
-                    "fr": "En-tête",
-                    "pt-PT": "Cabeçalho"
-                }
-            },
-            {
-                "type": "color",
-                "id": "header-background-color",
-                "label": {
-                    "en": "Background",
-                    "de": "Hintergrund",
-                    "es": "Fondo",
-                    "fr": "Contexte général",
-                    "pt-PT": "Fundo"
-                },
-                "default": "#ffffff"
-            },
-            {
-                "type": "color",
-                "id": "header-top-bar-color",
-                "label": {
-                    "en": "Top bar",
-                    "de": "Obere Leiste",
-                    "es": "Barra superior",
-                    "fr": "Barre supérieure",
-                    "pt-PT": "Barra Superior"
-                },
-                "default": "#F3F3F3"
-            },
-            {
-                "type": "color",
-                "id": "header-text-color",
-                "label": {
-                    "en": "Text",
-                    "de": "Text",
-                    "es": "Texto",
-                    "fr": "Texte",
-                    "pt-PT": "Texto"
-                },
-                "default": "#333333"
-            },
-            {
-                "type": "color",
-                "id": "header-overlay-text-color",
-                "label": {
-                    "en": "Overlay text",
-                    "de": "Überlagerter Text",
-                    "es": "Texto superpuesto",
-                    "fr": "Texte en superposition",
-                    "pt-PT": "Sobrepor Texto"
-                },
-                "default": "#ffffff"
-            },
-            {
-                "type": "header",
-                "content": {
-                    "en": "Sticky header",
-                    "fr": "En-tête fixe",
-                    "de": "Sticky Header",
-                    "es": "Encabezado adhesivo",
-                    "pt-PT": "Cabeçalho adesivo"
-                }
-            },
-            {
-                "type": "color",
-                "id": "sticky-header-background-color",
-                "label": {
-                    "en": "Background",
-                    "de": "Hintergrund",
-                    "es": "Fondo",
-                    "fr": "Contexte général",
-                    "pt-PT": "Fundo"
-                },
-                "default": "#ffffff"
-            },
-            {
-                "type": "color",
-                "id": "sticky-header-top-bar-color",
-                "label": {
-                    "en": "Top bar",
-                    "de": "Obere Leiste",
-                    "es": "Barra superior",
-                    "fr": "Barre supérieure",
-                    "pt-PT": "Barra Superior"
-                },
-                "default": "#F3F3F3"
-            },
-            {
-                "type": "color",
-                "id": "sticky-header-text-color",
-                "label": {
-                    "en": "Text",
-                    "de": "Text",
-                    "es": "Texto",
-                    "fr": "Texte",
-                    "pt-PT": "Texto"
-                },
-                "default": "#000000"
-            },
-            {
-                "type": "header",
-                "content": {
-                    "en": "Mobile navigation",
-                    "de": "Mobile Navigation",
-                    "es": "Navegación móvil",
-                    "fr": "Navigation mobile",
-                    "pt-PT": "Navegação móvel"
-                }
-            },
-            {
-                "type": "color",
-                "id": "sidebar-navigation--background-color",
-                "label": {
-                    "en": "Background",
-                    "de": "Hintergrund",
-                    "es": "Fondo",
-                    "fr": "Contexte général",
-                    "pt-PT": "Fundo"
-                },
-                "default": "#222222"
-            },
-            {
-                "type": "color",
-                "id": "sidebar-navigation--text-color",
-                "label": {
-                    "en": "Text",
-                    "de": "Text",
-                    "es": "Texto",
-                    "fr": "Texte",
-                    "pt-PT": "Texto"
-                },
-                "default": "#ffffff"
-            },
-            {
-                "type": "header",
-                "content": {
-                    "en": "Footer",
-                    "de": "Fußzeile",
-                    "es": "Pie de página",
-                    "fr": "Pied de page",
-                    "pt-PT": "Rodapé"
-                }
-            },
-            {
-                "type": "color",
-                "id": "footer-background-color",
-                "label": {
-                    "en": "Background",
-                    "de": "Hintergrund",
-                    "es": "Fondo",
-                    "fr": "Contexte général",
-                    "pt-PT": "Fundo"
-                },
-                "default": "#ebebeb"
-            },
-            {
-                "type": "color",
-                "id": "footer-text-color",
-                "label": {
-                    "en": "Text",
-                    "de": "Text",
-                    "es": "Texto",
-                    "fr": "Texte",
-                    "pt-PT": "Texto"
-                },
-                "default": "#333333"
-            },
-            {
-                "type": "header",
-                "content": {
-                    "en": "Buttons",
-                    "fr": "Boutons",
-                    "de": "Buttons",
-                    "es": "Botones",
-                    "pt-PT": "Botões"
-                }
-            },
-            {
-                "type": "color",
-                "id": "add-to-cart-background-color",
-                "label": {
-                    "en": "Background",
-                    "de": "Hintergrund",
-                    "es": "Fondo",
-                    "fr": "Contexte général",
-                    "pt-PT": "Fundo"
-                },
-                "default": "#212121"
-            },
-            {
-                "type": "color",
-                "id": "add-to-cart-background-hover-color",
-                "label": {
-                    "en": "Background hover",
-                    "fr": "Fond flottant",
-                    "de": "Hintergrund-Hover",
-                    "es": "Fondo con función «hover»",
-                    "pt-PT": "Passar o cursor sobre o fundo"
-                },
-                "default": "#000000"
-            },
-            {
-                "type": "color",
-                "id": "add-to-cart-text-color",
-                "label": {
-                    "en": "Text",
-                    "de": "Text",
-                    "es": "Texto",
-                    "fr": "Texte",
-                    "pt-PT": "Texto"
-                },
-                "default": "#fff"
-            },
-            {
-                "type": "header",
-                "content": {
-                    "en": "Popup",
-                    "fr": "Pop-up",
-                    "de": "Popup",
-                    "es": "Emergente",
-                    "pt-PT": "Popup"
-                }
-            },
-            {
-                "type": "color",
-                "id": "pop-up-background-color",
-                "label": {
-                    "en": "Background",
-                    "de": "Hintergrund",
-                    "es": "Fondo",
-                    "fr": "Contexte général",
-                    "pt-PT": "Fundo"
-                },
-                "default": "#333333"
-            },
-            {
-                "type": "color",
-                "id": "pop-up-text-color",
-                "label": {
-                    "en": "Text",
-                    "de": "Text",
-                    "es": "Texto",
-                    "fr": "Texte",
-                    "pt-PT": "Texto"
-                },
-                "default": "#fff"
-            },
-            {
-                "type": "header",
-                "content": {
-                    "en": "Image overlays",
-                    "fr": "Recouvrements d’images ",
-                    "de": "Bild-Overlay",
-                    "es": "Superposiciones de imagen",
-                    "pt-PT": "Sobreposições de imagem"
-                }
-            },
-            {
-                "type": "color",
-                "id": "color_image_overlay_text",
-                "label": {
-                    "en": "Text",
-                    "de": "Text",
-                    "es": "Texto",
-                    "fr": "Texte",
-                    "pt-PT": "Texto"
-                },
-                "default": "#fff"
-            },
-            {
-                "type": "color",
-                "id": "color_image_overlay",
-                "label": {
-                    "en": "Fade",
-                    "de": "Ausblenden",
-                    "es": "Desvanecerse",
-                    "fr": "Fondu",
-                    "pt-PT": "Desvanecer"
-                },
-                "default": "#000"
-            },
-            {
-                "type": "range",
-                "id": "image_overlay_opacity",
-                "min": 0,
-                "max": 95,
-                "step": 5,
-                "unit": {
-                    "en": "%",
-                    "de": "%",
-                    "es": "%",
-                    "fr": "%",
-                    "pt-PT": "%"
-                },
-                "label": {
-                    "en": "Overlay opacity",
-                    "de": "Überlagerungsdeckkraft",
-                    "es": "Capacidad de sobrexposición",
-                    "fr": "Opacité de superposition",
-                    "pt-PT": "Opacidade de sobreposição"
-                },
-                "default": 60
-            },
-            {
-                "type": "header",
-                "content": {
-                    "en": "Sale badge",
-                    "fr": "Badge « En solde »",
-                    "de": "Sale-Button",
-                    "es": "Cartel de «oferta»",
-                    "pt-PT": "Emblema de venda"
-                }
-            },
-            {
-                "type": "color",
-                "id": "sale-label-color",
-                "label": {
-                    "en": "Background",
-                    "de": "Hintergrund",
-                    "es": "Fondo",
-                    "fr": "Contexte général",
-                    "pt-PT": "Fundo"
-                },
-                "default": "#D62426"
-            },
-            {
-                "type": "color",
-                "id": "sale-label-text-color",
-                "label": {
-                    "en": "Text",
-                    "de": "Text",
-                    "es": "Texto",
-                    "fr": "Texte",
-                    "pt-PT": "Texto"
-                },
-                "default": "#ffffff"
-            },
-            {
-                "type": "header",
-                "content": {
-                    "en": "Sold out badge",
-                    "de": "Ausverkauft-Button",
-                    "es": "Cartel de «agotado»",
-                    "fr": "Badge « Épuisé »",
-                    "pt-PT": "Emblema de esgotado"
-                }
-            },
-            {
-                "type": "color",
-                "id": "sold-out-badge-color",
-                "label": {
-                    "en": "Background",
-                    "de": "Hintergrund",
-                    "es": "Fondo",
-                    "fr": "Contexte général",
-                    "pt-PT": "Fundo"
-                },
-                "default": "#000000"
-            },
-            {
-                "type": "color",
-                "id": "sold-out-badge-text-color",
-                "label": {
-                    "en": "Text",
-                    "de": "Text",
-                    "es": "Texto",
-                    "fr": "Texte",
-                    "pt-PT": "Texto"
-                },
-                "default": "#ffffff"
-            },
-            {
-                "type": "checkbox",
-                "id": "sold_out_badge",
-                "label": {
-                    "en": "Show sold out badge",
-                    "de": "Markierung für Ausverkauft anzeigen",
-                    "es": "Mostrar el distintivo de agotado",
-                    "fr": "Afficher le badge \"épuisé\"",
-                    "pt-PT": "Mostrar Crachá de Esgotado"
-                },
-                "default": true
-            },
-            {
-                "type": "header",
-                "content": {
-                    "en": "Free shipping banner",
-                    "de": "Banner für kostenlosen Versand",
-                    "es": "Anuncio de envío gratis",
-                    "fr": "Bannière de livraison gratuite",
-                    "pt-PT": "'Banner' de envio gratuito"
-                }
-            },
-            {
-                "type": "color",
-                "id": "free-shipping-background-color",
-                "label": {
-                    "en": "Background",
-                    "de": "Hintergrund",
-                    "es": "Fondo",
-                    "fr": "Contexte général",
-                    "pt-PT": "Fundo"
-                },
-                "default": "#BEBEBE"
-            },
-            {
-                "type": "color",
-                "id": "free-shipping-text-color",
-                "label": {
-                    "en": "Text",
-                    "de": "Text",
-                    "es": "Texto",
-                    "fr": "Texte",
-                    "pt-PT": "Texto"
-                },
-                "default": "#000000"
-            }
-        ]
-    },
-    {
-        "name": {
-            "en": "Typography",
-            "fr": "Typographie",
-            "de": "Typographie",
-            "es": "Tipografía",
-            "pt-PT": "Tipografia"
+        "default": "#333333"
+      },
+      {
+        "type": "color",
+        "id": "link-color",
+        "label": {
+          "en": "Link",
+          "de": "Link",
+          "es": "Enlace",
+          "fr": "Lien",
+          "pt-PT": "Ligação"
         },
-        "settings": [
-            {
-                "type": "header",
-                "content": {
-                    "en": "Headings",
-                    "fr": "Titres",
-                    "de": "Headings",
-                    "es": "Encabezados",
-                    "pt-PT": "Cabeçalhos"
-                }
-            },
-            {
-                "type": "font_picker",
-                "id": "type_header_font",
-                "label": {
-                    "en": "Font",
-                    "fr": "Police",
-                    "de": "Schriftart",
-                    "es": "Tipografía",
-                    "pt-PT": "Tipo de letra"
-                },
-                "default": "montserrat_n5"
-            },
-            {
-                "type": "select",
-                "id": "heading-case",
-                "label": {
-                    "en": "Heading case",
-                    "fr": "Casse de titre",
-                    "de": "Titelgröße",
-                    "es": "Formato del encabezado",
-                    "pt-PT": "Caixa do cabeçalho"
-                },
-                "default": "none",
-                "options": [
-                    {
-                        "value": "none",
-                        "label": {
-                            "en": "Normal case",
-                            "fr": "Casse normale",
-                            "de": "Normale Größe",
-                            "es": "Formato normal",
-                            "pt-PT": "Caixa normal"
-                        }
-                    },
-                    {
-                        "value": "lowercase",
-                        "label": {
-                            "en": "Lowercase",
-                            "fr": "Minuscules",
-                            "de": "Kleinschrift",
-                            "es": "Minúscula",
-                            "pt-PT": "Letra minúscula"
-                        }
-                    },
-                    {
-                        "value": "uppercase",
-                        "label": {
-                            "en": "Uppercase",
-                            "fr": "Majuscules",
-                            "de": "Großschrift",
-                            "es": "Mayúscula",
-                            "pt-PT": "Letra maiúscula"
-                        }
-                    }
-                ]
-            },
-            {
-                "type": "select",
-                "id": "heading--base-size",
-                "label": {
-                    "en": "Size",
-                    "fr": "Taille",
-                    "de": "Größe",
-                    "es": "Tamaño",
-                    "pt-PT": "Tamanho"
-                },
-                "options": [
-                    {
-                        "value": "small",
-                        "label": {
-                            "en": "Small",
-                            "de": "Klein",
-                            "es": "Pequeño",
-                            "fr": "Petite",
-                            "pt-PT": "Pequeno"
-                        }
-                    },
-                    {
-                        "value": "normal",
-                        "label": {
-                            "en": "Normal",
-                            "de": "Normal",
-                            "es": "Normal",
-                            "fr": "Normal",
-                            "pt-PT": "Normal"
-                        }
-                    },
-                    {
-                        "value": "large",
-                        "label": {
-                            "en": "Large",
-                            "de": "Groß",
-                            "es": "Grande",
-                            "fr": "Grande",
-                            "pt-PT": "Grande"
-                        }
-                    }
-                ]
-            },
-            {
-                "type": "header",
-                "content": {
-                    "en": "Subheadings",
-                    "de": "Unterüberschrift",
-                    "es": "Subencabezado",
-                    "fr": "Sous-rubrique",
-                    "pt-PT": "Subtítulo"
-                }
-            },
-            {
-                "type": "font_picker",
-                "id": "subheading--font",
-                "label": {
-                    "en": "Font",
-                    "fr": "Police",
-                    "de": "Schriftart",
-                    "es": "Tipografía",
-                    "pt-PT": "Tipo de letra"
-                },
-                "default": "roboto_n4"
-            },
-            {
-                "type": "select",
-                "id": "subheading--case",
-                "label": {
-                    "en": "Subheading case",
-                    "fr": "Casse de la sous-rubrique",
-                    "de": "Unterüberschrift Groß-/Kleinschreibung",
-                    "es": "Mayúsculas de subtítulos",
-                    "pt-PT": "Caixa de sub-título"
-                },
-                "default": "uppercase",
-                "options": [
-                    {
-                        "value": "none",
-                        "label": {
-                            "en": "Normal case",
-                            "fr": "Casse normale",
-                            "de": "Normale Größe",
-                            "es": "Formato normal",
-                            "pt-PT": "Caixa normal"
-                        }
-                    },
-                    {
-                        "value": "lowercase",
-                        "label": {
-                            "en": "Lowercase",
-                            "fr": "Minuscules",
-                            "de": "Kleinschrift",
-                            "es": "Minúscula",
-                            "pt-PT": "Letra minúscula"
-                        }
-                    },
-                    {
-                        "value": "uppercase",
-                        "label": {
-                            "en": "Uppercase",
-                            "fr": "Majuscules",
-                            "de": "Großschrift",
-                            "es": "Mayúscula",
-                            "pt-PT": "Letra maiúscula"
-                        }
-                    }
-                ]
-            },
-            {
-                "type": "header",
-                "content": {
-                    "en": "Body text",
-                    "fr": "Corps de texte",
-                    "de": "Textkörper",
-                    "es": "Texto principal",
-                    "pt-PT": "Corpo de texto"
-                }
-            },
-            {
-                "type": "font_picker",
-                "id": "type_base_font",
-                "label": {
-                    "en": "Font",
-                    "fr": "Police",
-                    "de": "Schriftart",
-                    "es": "Tipografía",
-                    "pt-PT": "Tipo de letra"
-                },
-                "default": "work_sans_n4"
-            },
-            {
-                "type": "range",
-                "id": "typography-body-font-size",
-                "min": 12,
-                "max": 22,
-                "step": 1,
-                "unit": {
-                    "en": "px",
-                    "de": "px",
-                    "es": "px",
-                    "fr": "px",
-                    "pt-PT": "px"
-                },
-                "label": {
-                    "en": "Base size",
-                    "fr": "Taille de base",
-                    "de": "Basisgröße",
-                    "es": "Tamaño base",
-                    "pt-PT": "Tamanho base"
-                },
-                "default": 14
-            },
-            {
-                "type": "header",
-                "content": {
-                    "en": "Navigation",
-                    "de": "Navigation",
-                    "es": "Navegación",
-                    "fr": "Navigation",
-                    "pt-PT": "Navegação"
-                }
-            },
-            {
-                "type": "select",
-                "id": "navigation--font",
-                "label": {
-                    "en": "Font",
-                    "fr": "Police",
-                    "de": "Schriftart",
-                    "es": "Tipografía",
-                    "pt-PT": "Tipo de letra"
-                },
-                "default": "body",
-                "options": [
-                    {
-                        "value": "body",
-                        "label": {
-                            "en": "Body",
-                            "de": "Textkörper",
-                            "es": "Texto principal",
-                            "fr": "Corps de texte",
-                            "pt-PT": "Corpo de texto"
-                        }
-                    },
-                    {
-                        "value": "subheading",
-                        "label": {
-                            "en": "Subheading",
-                            "de": "Unterüberschrift",
-                            "es": "Subencabezado",
-                            "fr": "Sous-rubrique",
-                            "pt-PT": "Subtítulo"
-                        }
-                    }
-                ]
-            },
-            {
-                "type": "checkbox",
-                "id": "navigation--capitalize",
-                "label": {
-                    "en": "Capitalize navigation",
-                    "de": "Navigation groß schreiben",
-                    "es": "Navegación en mayúsculas",
-                    "fr": "Mettre la navigation en majuscules",
-                    "pt-PT": "Capitalize navegação"
-                },
-                "default": true
-            },
-            {
-                "type": "header",
-                "content": {
-                    "en": "Buttons",
-                    "fr": "Boutons",
-                    "de": "Buttons",
-                    "es": "Botones",
-                    "pt-PT": "Botões"
-                }
-            },
-            {
-                "type": "select",
-                "id": "buttons--font",
-                "label": {
-                    "en": "Font",
-                    "fr": "Police",
-                    "de": "Schriftart",
-                    "es": "Tipografía",
-                    "pt-PT": "Tipo de letra"
-                },
-                "default": "body",
-                "options": [
-                    {
-                        "value": "body",
-                        "label": {
-                            "en": "Body",
-                            "de": "Textkörper",
-                            "es": "Texto principal",
-                            "fr": "Corps de texte",
-                            "pt-PT": "Corpo de texto"
-                        }
-                    },
-                    {
-                        "value": "subheading",
-                        "label": {
-                            "en": "Subheading",
-                            "de": "Unterüberschrift",
-                            "es": "Subencabezado",
-                            "fr": "Sous-rubrique",
-                            "pt-PT": "Subtítulo"
-                        }
-                    }
-                ]
-            },
-            {
-                "type": "range",
-                "id": "typography-buttons-font-size",
-                "min": 12,
-                "max": 18,
-                "step": 1,
-                "unit": {
-                    "en": "px",
-                    "de": "px",
-                    "es": "px",
-                    "fr": "px",
-                    "pt-PT": "px"
-                },
-                "label": {
-                    "en": "Size",
-                    "fr": "Taille",
-                    "de": "Größe",
-                    "es": "Tamaño",
-                    "pt-PT": "Tamanho"
-                },
-                "default": 14
-            },
-            {
-                "type": "checkbox",
-                "id": "buttons--capitalize",
-                "label": {
-                    "en": "Capitalize buttons",
-                    "de": "Schaltflächen groß schreiben",
-                    "es": "Botones en mayúsculas",
-                    "fr": "Mettre les boutons en majuscules",
-                    "pt-PT": "Capitalize os botões"
-                },
-                "default": true
-            }
-        ]
-    },
-    {
-        "name": {
-            "en": "Cart",
-            "fr": "Panier",
-            "de": "Einkaufswagen",
-            "es": "Carrito",
-            "pt-PT": "Carrinho"
+        "default": "#333333"
+      },
+      {
+        "type": "color",
+        "id": "active-link-color",
+        "label": {
+          "en": "Active link",
+          "fr": "Lien actif",
+          "de": "Aktiver Link",
+          "es": "Enlace activo",
+          "pt-PT": "Ligação ativa"
         },
-        "settings": [
-            {
-                "type": "header",
-                "content": {
-                    "en": "Cart",
-                    "fr": "Panier",
-                    "de": "Einkaufswagen",
-                    "es": "Carrito",
-                    "pt-PT": "Carrinho"
-                }
-            },
-            {
-                "type": "select",
-                "id": "cart-type",
-                "label": {
-                    "en": "Cart type",
-                    "fr": "Type de panier",
-                    "de": "Einkaufswagenart",
-                    "es": "Tipo de carrito",
-                    "pt-PT": "Tipo de carrinho"
-                },
-                "options": [
-                    {
-                        "value": "drawer",
-                        "label": {
-                            "en": "Drawer",
-                            "fr": "Tiroir",
-                            "de": "Schublade",
-                            "es": "Cajón",
-                            "pt-PT": "Gaveta"
-                        }
-                    },
-                    {
-                        "value": "persistent",
-                        "label": {
-                            "en": "Fixed",
-                            "de": "Festgestellt",
-                            "es": "Fijo",
-                            "fr": "Fixe",
-                            "pt-PT": "Fixo"
-                        }
-                    },
-                    {
-                        "value": "page",
-                        "label": {
-                            "en": "Page",
-                            "de": "Seite",
-                            "es": "Página",
-                            "fr": "Page",
-                            "pt-PT": "Página"
-                        }
-                    }
-                ],
-                "default": "page"
-            },
-            {
-                "type": "radio",
-                "id": "cart-action",
-                "label": {
-                    "en": "Add to Cart action",
-                    "de": "Aktion „Zum Einkaufswagen hinzufügen“",
-                    "es": "Acción de Añadir al carrito",
-                    "fr": "Action d'ajout au panier",
-                    "pt-PT": "Ação Adicionar ao Carrinho"
-                },
-                "options": [
-                    {
-                        "value": "added",
-                        "label": {
-                            "en": "Show 'Added' message",
-                            "de": "„Hinzugefügt“-Mitteilung zeigen",
-                            "es": "Mostar el mensaje de «Añadido»",
-                            "fr": "Afficher le message « Ajouté »",
-                            "pt-PT": "Mostrar mensagem \"Adicionado\""
-                        }
-                    },
-                    {
-                        "value": "cart",
-                        "label": {
-                            "en": "Go to cart",
-                            "de": "Zum Einkaufswagen gehen",
-                            "es": "Ir al carrito",
-                            "fr": "Aller au panier",
-                            "pt-PT": "Ir para o carrinho"
-                        }
-                    }
-                ],
-                "default": "cart"
-            },
-            {
-                "type": "checkbox",
-                "id": "enable-additional-checkout-buttons",
-                "label": {
-                    "en": "Enable dynamic checkout buttons",
-                    "de": "Dynamische Checkout-Buttons aktivieren",
-                    "es": "Habilitar los botones de compra dinámica",
-                    "fr": "Activer les boutons de caisse dynamiques",
-                    "pt-PT": "Ativar botões de checkout dinâmicos"
-                },
-                "info": {
-                    "en": "[Learn more](https://help.shopify.com/en/manual/sell-online/online-store/dynamic-checkout)",
-                    "de": "[Mehr erfahren](https://help.shopify.com/en/manual/sell-online/online-store/dynamic-checkout)",
-                    "es": "[Aprenda más](https://help.shopify.com/en/manual/sell-online/online-store/dynamic-checkout)",
-                    "fr": "[En savoir plus](https://help.shopify.com/en/manual/sell-online/online-store/dynamic-checkout)",
-                    "pt-PT": "[Saber mais](https://help.shopify.com/en/manual/sell-online/online-store/dynamic-checkout)"
-                },
-                "default": true
-            },
-            {
-                "type": "checkbox",
-                "id": "allow_note",
-                "label": {
-                    "en": "Enable cart notes",
-                    "fr": "Activer les commentaires du panier",
-                    "de": "Aktiviere Einkaufswagen-Notizen",
-                    "es": "Activar comentarios en carrito",
-                    "pt-PT": "Ativar notas de carrinho"
-                },
-                "default": false
-            },
-            {
-                "type": "header",
-                "content": {
-                    "en": "Fixed cart",
-                    "fr": "Panier fixe",
-                    "de": "Fester Warenkorb",
-                    "es": "Carro fijo",
-                    "pt-PT": "Carrinho de compras fixo"
-                }
-            },
-            {
-                "type": "select",
-                "id": "persistent-cart-visibility",
-                "label": {
-                    "en": "Visibility",
-                    "de": "Sichtbarkeit",
-                    "es": "Visibilidad",
-                    "fr": "Visibilité",
-                    "pt-PT": "Visibilidade"
-                },
-                "options": [
-                    {
-                        "value": "all_pages",
-                        "label": {
-                            "en": "All pages",
-                            "de": "Alle Seiten",
-                            "es": "Todas las páginas",
-                            "fr": "Toutes les pages",
-                            "pt-PT": "Todas as páginas"
-                        }
-                    },
-                    {
-                        "value": "product_collection",
-                        "label": {
-                            "en": "Product and collection pages only",
-                            "de": "Nur Produkt- und Kollektionsseiten",
-                            "es": "Solo páginas de productos y colecciones",
-                            "fr": "Pages de produits et de collections uniquement",
-                            "pt-PT": "Apenas páginas de produtos e coleções"
-                        }
-                    }
-                ]
-            },
-            {
-                "type": "header",
-                "content": {
-                    "en": "Encouragement",
-                    "fr": "Encouragement",
-                    "de": "Ermutigung",
-                    "es": "Estímulo",
-                    "pt-PT": "Encorajamento"
-                }
-            },
-            {
-                "type": "checkbox",
-                "id": "enable_shipping_encouragement",
-                "label": {
-                    "en": "Enable free shipping encouragement",
-                    "fr": "Activer l'encouragement à la livraison gratuite",
-                    "de": "Ermöglichung des kostenlosen Versands Ermutigung",
-                    "es": "Habilitar el estímulo para el envío gratuito",
-                    "pt-PT": "Ativar o incentivo ao envio gratuito"
-                },
-                "default": true
-            },
-            {
-                "type": "text",
-                "id": "free_shipping_message",
-                "label": {
-                    "en": "Free shipping message",
-                    "fr": "Message de livraison gratuite",
-                    "de": "Kostenlose Versandnachricht",
-                    "es": "Mensaje de envío gratis",
-                    "pt-PT": "Mensagem de envio gratuito"
-                },
-                "info": {
-                    "en": "Please ensure the <price> placeholder remains in your text",
-                    "fr": "Veuillez vous assurer que l'espace réservé <price> reste dans votre texte",
-                    "de": "Bitte stellen Sie sicher, dass der <price>-Platzhalter in Ihrem Text bleibt",
-                    "es": "Asegúrese de que el marcador de posición <price> permanece en su texto",
-                    "pt-PT": "Assegure-se de que o <price>'placeholder' permanece no seu texto"
-                },
-                "default": {
-                    "en": "Spend <price> more and get free shipping!",
-                    "fr": "Dépensez <price> de plus et bénéficiez de la livraison gratuite !",
-                    "de": "Geben Sie <price> mehr aus und erhalten Sie kostenlosen Versand!",
-                    "es": "Gaste más de <price> y obtenga envíos gratis",
-                    "pt-PT": "Gaste <price> mais e obtenha envio gratuito!"
-                }
-            },
-            {
-                "type": "text",
-                "id": "free_shipping_achieved",
-                "label": {
-                    "en": "Free shipping achieved message",
-                    "fr": "Message de livraison gratuite réalisée",
-                    "de": "Kostenloser Versand erreicht Nachricht",
-                    "es": "Mensaje de envío gratis logrado",
-                    "pt-PT": "Mensagem de obtenção de envio gratuito"
-                },
-                "default": {
-                    "en": "Your cart qualifies for free shipping!",
-                    "fr": "Votre panier remplit les conditions requises pour la livraison gratuite !",
-                    "de": "Ihr Warenkorb ist für kostenlosen Versand qualifiziert!",
-                    "es": "¡Su carrito cumple los requisitos para tener envío gratuito!",
-                    "pt-PT": "O seu carrinho tem direito a envio gratuito!"
-                }
-            },
-            {
-                "type": "text",
-                "id": "free_shipping_amount",
-                "label": {
-                    "en": "Free shipping when cart total is equal or larger than: ",
-                    "de": "Kostenloser Versand, wenn die Warenkorbsumme gleich oder größer als ist:",
-                    "es": "Envío gratis cuando el total del carrito sea igual o mayor que:",
-                    "fr": "Livraison gratuite lorsque le total du panier est égal ou supérieur à :",
-                    "pt-PT": "Envio gratuito quando o total do carrinho for igual ou maior do que:"
-                },
-                "default": {
-                    "en": "30.00",
-                    "de": "30.00",
-                    "es": "30.00",
-                    "fr": "30.00",
-                    "pt-PT": "30.00"
-                }
-            }
-        ]
-    },
-    {
-        "name": {
-            "en": "Products",
-            "fr": "Produits",
-            "de": "Produkte",
-            "es": "Productos",
-            "pt-PT": "Produtos"
+        "default": "#333333"
+      },
+      {
+        "type": "color",
+        "id": "bg_color",
+        "label": {
+          "en": "Background",
+          "de": "Hintergrund",
+          "es": "Fondo",
+          "fr": "Contexte général",
+          "pt-PT": "Fundo"
         },
-        "settings": [
-            {
-                "type": "checkbox",
-                "id": "show_sale_price",
-                "label": {
-                    "en": "Show sale price",
-                    "de": "Verkaufspreis anzeigen",
-                    "es": "Mostrar precio de oferta",
-                    "fr": "Afficher le prix de vente",
-                    "pt-PT": "Mostrar preço de venda"
-                },
-                "default": true
-            },
-            {
-                "type": "checkbox",
-                "id": "show_sale_badge",
-                "label": {
-                    "en": "Show sale badge",
-                    "de": "Markierung für Aktionen anzeigen",
-                    "es": "Mostrar el distintivo de en venta",
-                    "fr": "Afficher le badge \"en vente\"",
-                    "pt-PT": "Mostrar Crachá de Venda"
-                },
-                "default": true
-            },
-            {
-                "type": "checkbox",
-                "id": "enable_store_pickup",
-                "label": {
-                    "en": "Show local pickup",
-                    "de": "Örtliche Abholung anzeigen",
-                    "es": "Mostrar recogida local",
-                    "fr": "Afficher le ramassage local",
-                    "pt-PT": "Mostrar a recolha local"
-                },
-                "info": {
-                    "en": "You will need to set your pickup locations to enable. [Learn more](https://help.shopify.com/en/manual/locations)",
-                    "de": "Sie müssen zum Aktivieren Ihre örtlichen Abholstellen festlegen. [Mehr erfahren](https://help.shopify.com/de/manual/locations)",
-                    "es": "Deberás configurar los lugares de recogida para habilitarlo. [Más información](https://help.shopify.com/es/manual/locations)",
-                    "fr": "Vous devrez définir vos lieux de ramassage pour activer. [En savoir plus](https://help.shopify.com/fr/manual/locations)",
-                    "pt-PT": "Precisará de definir as suas localizações de recolha para ativar. [Saber mais](https://help.shopify.com/pt-PT/manual/locations)"
-                },
-                "default": true
-            },
-            {
-                "type": "header",
-                "content": {
-                    "en": "Product grids",
-                    "de": "Produktgitter",
-                    "es": "Tablas de productos",
-                    "fr": "Grilles de produits",
-                    "pt-PT": "Grelhas de produtos"
-                }
-            },
-            {
-                "type": "select",
-                "id": "product-grid",
-                "label": {
-                    "en": "Grid image size",
-                    "fr": "Taille de l'image de la grille",
-                    "de": "Rasterbildgröße",
-                    "es": "Tamaño de imagen de la cuadrícula",
-                    "pt-PT": "Tamanho das imagens da grelha"
-                },
-                "default": "natural",
-                "options": [
-                    {
-                        "value": "natural",
-                        "label": {
-                            "en": "Natural",
-                            "fr": "Naturel",
-                            "de": "Natürlich",
-                            "es": "Natural",
-                            "pt-PT": "Natural"
-                        }
-                    },
-                    {
-                        "value": "square",
-                        "label": {
-                            "en": "Square (1:1)",
-                            "fr": "Carré (1: 1)",
-                            "de": "Quadrat (1:1)",
-                            "es": "Cuadrado (1:1)",
-                            "pt-PT": "Quadrado (1:1)"
-                        }
-                    },
-                    {
-                        "value": "tall",
-                        "label": {
-                            "en": "Tall (2:3)",
-                            "fr": "Grand (2: 3)",
-                            "de": "Groß (2:3)",
-                            "es": "Vertical (2:3)",
-                            "pt-PT": "Estreito (2:3)"
-                        }
-                    },
-                    {
-                        "value": "wide",
-                        "label": {
-                            "en": "Wide (4:3)",
-                            "fr": "Large (4: 3)",
-                            "de": "Weit (4:3)",
-                            "es": "Ancho (4:3)",
-                            "pt-PT": "Largo (4:3)"
-                        }
-                    }
-                ]
-            },
-            {
-                "type": "checkbox",
-                "id": "product_padding_enable",
-                "label": {
-                    "en": "Image padding",
-                    "de": "Image-Padding",
-                    "es": "Relleno de imagen",
-                    "fr": "Remplissage d'image",
-                    "pt-PT": "Revestimento de imagem"
-                },
-                "default": false
-            },
-            {
-                "type": "checkbox",
-                "id": "center_align",
-                "label": {
-                    "en": "Center align product text",
-                    "de": "Produkttext zentriert ausrichten",
-                    "es": "Alinear el texto del producto en el centro",
-                    "fr": "Centrer le texte du produit",
-                    "pt-PT": "Alinhar o texto do produto ao centro"
-                },
-                "default": false
-            },
-            {
-                "type": "checkbox",
-                "id": "borders_enable",
-                "label": {
-                    "en": "Show borders",
-                    "de": "Grenzen anzeigen",
-                    "es": "Mostrar bordes",
-                    "fr": "Afficher les bordures",
-                    "pt-PT": "Mostrar margens"
-                },
-                "default": false
-            },
-            {
-                "type": "select",
-                "id": "hover_effect",
-                "label": {
-                    "en": "Product hover effect",
-                    "de": "Hover-Effekt",
-                    "es": "Efecto al pasar el cursor por encima",
-                    "fr": "Effet de survol",
-                    "pt-PT": "Efeito hover"
-                },
-                "default": "none",
-                "options": [
-                    {
-                        "value": "none",
-                        "label": {
-                            "en": "None",
-                            "de": "Keiner",
-                            "es": "Ninguno",
-                            "fr": "Aucun",
-                            "pt-PT": "Nenhum"
-                        }
-                    },
-                    {
-                        "value": "zoom",
-                        "label": {
-                            "en": "Zoom",
-                            "de": "Zoom",
-                            "es": "Zoom",
-                            "fr": "Zoom",
-                            "pt-PT": "Aumentar"
-                        }
-                    },
-                    {
-                        "value": "shadow",
-                        "label": {
-                            "en": "Shadow",
-                            "de": "Schatten",
-                            "es": "Sombreado",
-                            "fr": "Ombre",
-                            "pt-PT": "Sombra"
-                        }
-                    }
-                ]
-            },
-            {
-                "type": "select",
-                "id": "quick_add_position",
-                "label": {
-                    "en": "Quick add position",
-                    "de": "Position schnell hinzufügen",
-                    "es": "Posición de adición rápida",
-                    "fr": "Position d'ajout rapide",
-                    "pt-PT": "Adicionar posição rapidamente"
-                },
-                "default": "none",
-                "options": [
-                    {
-                        "value": "none",
-                        "label": {
-                            "en": "None",
-                            "de": "Keiner",
-                            "es": "Ninguno",
-                            "fr": "Aucun",
-                            "pt-PT": "Nenhum"
-                        }
-                    },
-                    {
-                        "value": "above_product_details",
-                        "label": {
-                            "en": "Above product details",
-                            "de": "Oberhalb der Produktdetails",
-                            "es": "Detalles del producto de arriba",
-                            "fr": "Au-dessus des informations du produit",
-                            "pt-PT": "Acima dos detalhes do produto"
-                        }
-                    },
-                    {
-                        "value": "below_product_details",
-                        "label": {
-                            "en": "Below product details",
-                            "de": "Unterhalb der Produktdetails",
-                            "es": "Detalles del producto de debajo",
-                            "fr": "Ci-dessous les informations du produit",
-                            "pt-PT": "Abaixo dos detalhes do produto"
-                        }
-                    }
-                ]
-            }
-        ]
-    },
-    {
-        "name": {
-            "en": "Social media",
-            "de": "Social Media",
-            "es": "Redes sociales",
-            "fr": "Médias sociaux",
-            "pt-PT": "Redes sociais"
+        "default": "#ffffff"
+      },
+      {
+        "type": "color",
+        "id": "border-color",
+        "label": {
+          "en": "Borders",
+          "de": "Borders",
+          "es": "Bordes",
+          "fr": "Bordures",
+          "pt-PT": "Margens"
         },
-        "settings": [
-            {
-                "type": "header",
-                "content": {
-                    "en": "Accounts",
-                    "fr": "Comptes",
-                    "de": "Konten",
-                    "es": "Cuentas",
-                    "pt-PT": "Contas"
-                }
-            },
-            {
-                "type": "text",
-                "id": "sm_facebook_link",
-                "label": {
-                    "en": "Facebook",
-                    "de": "Facebook",
-                    "es": "Facebook",
-                    "fr": "Facebook",
-                    "pt-PT": "Facebook"
-                },
-                "info": {
-                    "en": "https://www.facebook.com/shopify",
-                    "fr": "https://www.facebook.com/shopify",
-                    "de": "https://www.facebook.com/shopify",
-                    "es": "https://www.facebook.com/shopify",
-                    "pt-PT": "https://www.facebook.com/shopify"
-                }
-            },
-            {
-                "type": "text",
-                "id": "sm_twitter_link",
-                "label": {
-                    "en": "Twitter",
-                    "de": "Twitter",
-                    "es": "Twitter",
-                    "fr": "Twitter",
-                    "pt-PT": "Twitter"
-                },
-                "info": {
-                    "en": "https://twitter.com/shopify",
-                    "fr": "https://twitter.com/shopify",
-                    "de": "https://twitter.com/shopify",
-                    "es": "https://twitter.com/shopify",
-                    "pt-PT": "https://twitter.com/shopify"
-                }
-            },
-            {
-                "type": "text",
-                "id": "sm_instagram_link",
-                "label": {
-                    "en": "Instagram",
-                    "de": "Instagram",
-                    "es": "Instagram",
-                    "fr": "Instagram",
-                    "pt-PT": "Instagram"
-                },
-                "info": {
-                    "en": "https://instagram.com/shopify",
-                    "fr": "https://instagram.com/shopify",
-                    "de": "https://instagram.com/shopify",
-                    "es": "https://instagram.com/shopify",
-                    "pt-PT": "https://instagram.com/shopify"
-                }
-            },
-            {
-                "type": "text",
-                "id": "sm_youtube_link",
-                "label": {
-                    "en": "YouTube",
-                    "fr": "YouTube",
-                    "de": "YouTube",
-                    "es": "YouTube",
-                    "pt-PT": "YouTube"
-                },
-                "info": {
-                    "en": "https://www.youtube.com/user/shopify",
-                    "fr": "https://www.youtube.com/user/shopify",
-                    "de": "https://www.youtube.com/user/shopify",
-                    "es": "https://www.youtube.com/user/shopify",
-                    "pt-PT": "https://www.youtube.com/user/shopify"
-                }
-            },
-            {
-                "type": "text",
-                "id": "sm_vimeo_link",
-                "label": {
-                    "en": "Vimeo",
-                    "fr": "Vimeo",
-                    "de": "Vimeo",
-                    "es": "Vimeo",
-                    "pt-PT": "Vimeo"
-                },
-                "info": {
-                    "en": "https://www.vimeo.com/shopify",
-                    "fr": "https://www.vimeo.com/shopify",
-                    "de": "https://www.vimeo.com/shopify",
-                    "es": "https://www.vimeo.com/shopify",
-                    "pt-PT": "https://www.vimeo.com/shopify"
-                }
-            },
-            {
-                "type": "text",
-                "id": "sm_tiktok_link",
-                "label": {
-                    "en": "TikTok",
-                    "fr": "TikTok",
-                    "de": "TikTok",
-                    "es": "TikTok",
-                    "pt-PT": "TikTok"
-                },
-                "info": {
-                    "en": "https://www.tiktok.com/@shopify",
-                    "fr": "https://www.tiktok.com/@shopify",
-                    "de": "https://www.tiktok.com/@shopify",
-                    "es": "https://www.tiktok.com/@shopify",
-                    "pt-PT": "https://www.tiktok.com/@shopify"
-                }
-            },
-            {
-                "type": "text",
-                "id": "sm_pinterest_link",
-                "label": {
-                    "en": "Pinterest",
-                    "de": "Pinterest",
-                    "es": "Pinterest",
-                    "fr": "Pinterest",
-                    "pt-PT": "Pinterest"
-                },
-                "info": {
-                    "en": "https://www.pinterest.com/shopify",
-                    "fr": "https://www.pinterest.com/shopify",
-                    "de": "https://www.pinterest.com/shopify",
-                    "es": "https://www.pinterest.com/shopify",
-                    "pt-PT": "https://www.pinterest.com/shopify"
-                }
-            },
-            {
-                "type": "text",
-                "id": "sm_snapchat_link",
-                "label": {
-                    "en": "Snapchat",
-                    "fr": "Snapchat",
-                    "de": "Snapchat",
-                    "es": "Snapchat",
-                    "pt-PT": "Snapchat"
-                },
-                "info": {
-                    "en": "https://snapchat.com/add/shopify",
-                    "fr": "https://snapchat.com/add/shopify",
-                    "de": "https://snapchat.com/add/shopify",
-                    "es": "https://snapchat.com/add/shopify",
-                    "pt-PT": "https://snapchat.com/add/shopify"
-                }
-            },
-            {
-                "type": "text",
-                "id": "sm_houzz_link",
-                "label": {
-                    "en": "Houzz",
-                    "fr": "Houzz",
-                    "de": "Houzz",
-                    "es": "Houzz",
-                    "pt-PT": "Houzz"
-                },
-                "info": {
-                    "en": "https://www.houzz.com/user",
-                    "fr": "https://www.houzz.com/user",
-                    "de": "https://www.houzz.com/user",
-                    "es": "https://www.houzz.com/user",
-                    "pt-PT": "https://www.houzz.com/user"
-                }
-            },
-            {
-                "type": "text",
-                "id": "sm_tumblr_link",
-                "label": {
-                    "en": "Tumblr",
-                    "fr": "Tumblr",
-                    "de": "Tumblr",
-                    "es": "Tumblr",
-                    "pt-PT": "Tumblr"
-                },
-                "info": {
-                    "en": "http://shopify.tumblr.com",
-                    "fr": "http://shopify.tumblr.com",
-                    "de": "http://shopify.tumblr.com",
-                    "es": "http://shopify.tumblr.com",
-                    "pt-PT": "http://shopify.tumblr.com"
-                }
-            },
-            {
-                "type": "text",
-                "id": "sm_linkedin_link",
-                "label": {
-                    "en": "LinkedIn",
-                    "fr": "LinkedIn",
-                    "de": "LinkedIn",
-                    "es": "LinkedIn",
-                    "pt-PT": "LinkedIn"
-                },
-                "info": {
-                    "en": "https://linkedin.com/company/shopify",
-                    "fr": "https://linkedin.com/company/shopify",
-                    "de": "https://linkedin.com/company/shopify",
-                    "es": "https://linkedin.com/company/shopify",
-                    "pt-PT": "https://linkedin.com/company/shopify"
-                }
-            }
-        ]
-    },
-    {
-        "name": {
-            "en": "Verification pop up",
-            "de": "Verifizierungs-Pop-up",
-            "es": "Ventana emergente de verificación",
-            "fr": "Fenêtre de vérification",
-            "pt-PT": "Pop-up de verificação"
+        "default": "#BEBEBE"
+      },
+      {
+        "type": "header",
+        "content": {
+          "en": "Header",
+          "de": "Überschrift",
+          "es": "Encabezado",
+          "fr": "En-tête",
+          "pt-PT": "Cabeçalho"
+        }
+      },
+      {
+        "type": "color",
+        "id": "header-background-color",
+        "label": {
+          "en": "Background",
+          "de": "Hintergrund",
+          "es": "Fondo",
+          "fr": "Contexte général",
+          "pt-PT": "Fundo"
         },
-        "settings": [
-            {
-                "type": "checkbox",
-                "id": "enable_verification_popup",
-                "default": false,
-                "label": {
-                    "en": "Enable verification pop up",
-                    "de": "Verifizierungs-Pop-up aktivieren",
-                    "es": "Activar ventana emergente de verificación",
-                    "fr": "Activer la fenêtre de vérification",
-                    "pt-PT": "Ativar pop-up de verificação"
-                }
-            },
-            {
-                "type": "checkbox",
-                "id": "verification-pop-up__test-mode",
-                "label": {
-                    "en": "Enable test mode",
-                    "fr": "Activer le mode test",
-                    "de": "Aktiviere Testmodus",
-                    "es": "Activar modo de prueba",
-                    "pt-PT": "Ativar modo de teste"
-                },
-                "info": {
-                    "en": "Forces the verification to show on every refresh, and should only be used for editing the popup. Ensure 'Test mode' is disabled when launching your store.",
-                    "de": "Erzwingt das Erscheinen des Verifizierungs-Pop-ups bei jeder Aktualisierung und sollte nur zum Bearbeiten des Pop-ups verwendet werden. Stellen Sie sicher, dass 'Testmodus' deaktiviert ist, wenn Sie Ihren Shop in Betrieb.",
-                    "es": "Hace que la verificación se muestre cada vez que se recargue la página. Solo debe usarse para editar la ventana emergente. Asegúrate de que el \"Modo de prueba\" esté desactivado al abrir tu tienda.",
-                    "fr": "Force la vérification à s'afficher à chaque actualisation, ne doit être utilisé que pour modifier la fenêtre contextuelle. Assurez-vous que le « mode test » est désactivé lors du lancement de votre boutique.",
-                    "pt-PT": "Força a mostrar a verificação em cada atualização e deve ser utilizado apenas para editar o pop-up. Confirme que o 'Modo de Teste' está desativado quando abrir a sua loja."
-                }
-            },
-            {
-                "type": "header",
-                "content": {
-                    "en": "Background color",
-                    "de": "Hintergrundfarbe",
-                    "es": "Color de fondo",
-                    "fr": "Couleur de l'arrière plan",
-                    "pt-PT": "Cor de fundo"
-                }
-            },
-            {
-                "type": "color",
-                "id": "verification-popup--background-color",
-                "label": {
-                    "en": "Background",
-                    "de": "Hintergrund",
-                    "es": "Fondo",
-                    "fr": "Contexte général",
-                    "pt-PT": "Fundo"
-                },
-                "default": "#333333"
-            },
-            {
-                "type": "header",
-                "content": {
-                    "en": "Background image",
-                    "de": "Hintergrundbild",
-                    "es": "Imagen de fondo",
-                    "fr": "Image d'arrière-plan",
-                    "pt-PT": "Imagem de fundo"
-                }
-            },
-            {
-                "type": "image_picker",
-                "id": "verification-popup--background-image",
-                "label": {
-                    "en": "Image",
-                    "de": "Bild",
-                    "es": "Imagen",
-                    "fr": "Image",
-                    "pt-PT": "Imagem"
-                },
-                "info": {
-                    "en": "2000 x 800px recommended",
-                    "de": "2000 x 800 px empfohlen",
-                    "es": "Recomendado 2000 x 800 px",
-                    "fr": "2000 x 800 px recommandé",
-                    "pt-PT": "2000 x 800px, recomendado"
-                }
-            },
-            {
-                "type": "header",
-                "content": {
-                    "en": "Logo",
-                    "de": "Logo",
-                    "es": "Logotipo",
-                    "fr": "Logo",
-                    "pt-PT": "Logótipo"
-                }
-            },
-            {
-                "type": "image_picker",
-                "id": "verification-popup__logo",
-                "label": {
-                    "en": "Logo image",
-                    "de": "Logobild",
-                    "es": "Imagen del logotipo",
-                    "fr": "Image du logo",
-                    "pt-PT": "Imagem do logótipo"
-                },
-                "info": {
-                    "en": "250 x 133px recommended",
-                    "de": "250 x 133 px empfohlen",
-                    "es": "Recomendado 250 x 133 px",
-                    "fr": "250 x 133 px recommandé",
-                    "pt-PT": "250 x 133px, recomendado"
-                }
-            },
-            {
-                "type": "range",
-                "id": "verification-popup-logo--max-width",
-                "min": 50,
-                "max": 500,
-                "step": 10,
-                "unit": {
-                    "en": "px",
-                    "de": "px",
-                    "es": "px",
-                    "fr": "px",
-                    "pt-PT": "px"
-                },
-                "label": {
-                    "en": "Preferred width",
-                    "de": "Bevorzugte Breite",
-                    "es": "Ancho preferido",
-                    "fr": "Largeur préférée",
-                    "pt-PT": "Largura preferida"
-                },
-                "default": 50
-            },
-            {
-                "type": "header",
-                "content": {
-                    "en": "Verification question",
-                    "de": "Verifizierungsfrage",
-                    "es": "Pregunta de verificación",
-                    "fr": "Question de vérification",
-                    "pt-PT": "Questão de verificação"
-                }
-            },
-            {
-                "type": "text",
-                "id": "verification-pop-up__header",
-                "label": {
-                    "en": "Heading",
-                    "de": "Überschrift",
-                    "es": "Encabezado",
-                    "fr": "Rubrique",
-                    "pt-PT": "Título"
-                },
-                "default": {
-                    "en": "Confirm your age",
-                    "de": "Bestätigen Sie Ihr Alter",
-                    "es": "Confirma tu edad",
-                    "fr": "Confirmez votre âge",
-                    "pt-PT": "Confirme a sua idade"
-                }
-            },
-            {
-                "type": "richtext",
-                "id": "verification-pop-up__description",
-                "label": {
-                    "en": "Verification question",
-                    "de": "Verifizierungsfrage",
-                    "es": "Pregunta de verificación",
-                    "fr": "Question de vérification",
-                    "pt-PT": "Questão de verificação"
-                },
-                "default": {
-                    "en": "<p>You must be at least 21 years old to enter this store.</p><p>Are you over 21 years of age?</p>",
-                    "de": "<p>Sie müssen mindestens 21 Jahre alt sein, um diesen Shop zu betreten.</p><p>Sind Sie über 21 Jahre alt?</p>",
-                    "es": "<p>Debes ser mayor de 21 años para entrar a esta tienda.</p><p>¿Tienes más de 21 años?</p>",
-                    "fr": "<p>Vous devez avoir au moins 21 ans pour entrer dans ce magasin.</p><p>Avez-vous plus de 21 ans?</p>",
-                    "pt-PT": "<p>Deve ter pelo menos 21 anos para entrar nesta loja.</p><p>Tem mais de 21 anos?</p>"
-                }
-            },
-            {
-                "type": "text",
-                "id": "exit-button__text",
-                "label": {
-                    "en": "Decline button text",
-                    "de": "Ablehnungs-Buttontext",
-                    "es": "Texto del botón de rechazo",
-                    "fr": "Texte du bouton de refus",
-                    "pt-PT": "Texto do botão de recusar"
-                },
-                "default": {
-                    "en": "No I'm not",
-                    "de": "<p>Nein, bin ich nicht</p>",
-                    "es": "<p>No</p>",
-                    "fr": "<p>Non</p>",
-                    "pt-PT": "<p>Não, não tenho</p>"
-                }
-            },
-            {
-                "type": "text",
-                "id": "confirm-button__text",
-                "label": {
-                    "en": "Approve button text",
-                    "de": "Bestätigungs-Buttontext",
-                    "es": "Texto del botón de aprobación",
-                    "fr": "Texte du bouton de validation",
-                    "pt-PT": "Texto do botão de aprovar"
-                },
-                "default": {
-                    "en": "Yes I am",
-                    "de": "<p>Ja, bin ich</p>",
-                    "es": "<p>Sí</p>",
-                    "fr": "<p>Oui</p>",
-                    "pt-PT": "<p>Sim, tenho</p>"
-                }
-            },
-            {
-                "type": "header",
-                "content": {
-                    "en": "Declined",
-                    "de": "Abgelehnt",
-                    "es": "Acceso denegado",
-                    "fr": "Refusé",
-                    "pt-PT": "Recusado"
-                },
-                "info": {
-                    "en": "This content will display if the user does not meet the verification requirements.",
-                    "de": "Dieser Inhalt wird angezeigt, wenn der Nutzer die Verifizierungsbedingungen nicht erfüllt.",
-                    "es": "Este mensaje se mostrará si el usuario no cumple con los requisitos de verificación.",
-                    "fr": "Ce contenu s'affichera si l'utilisateur ne répond pas aux exigences de vérification.",
-                    "pt-PT": "Este conteúdo será exibido se o utilizador não cumprir os requisitos de verificação."
-                }
-            },
-            {
-                "type": "text",
-                "id": "deny__header",
-                "label": {
-                    "en": "Heading",
-                    "de": "Überschrift",
-                    "es": "Encabezado",
-                    "fr": "Rubrique",
-                    "pt-PT": "Título"
-                },
-                "default": {
-                    "en": "Come back when you're older",
-                    "de": "Kommen Sie wieder, wenn Sie älter sind",
-                    "es": "Vuelve cuando seas mayor",
-                    "fr": "Reviens quand tu seras plus vieux",
-                    "pt-PT": "Volte quando for mais velho"
-                }
-            },
-            {
-                "type": "richtext",
-                "id": "deny__description",
-                "label": {
-                    "en": "Text",
-                    "de": "Text",
-                    "es": "Texto",
-                    "fr": "Texte",
-                    "pt-PT": "Texto"
-                },
-                "default": {
-                    "en": "<p>It looks like you're not old enough to shop with us, come back when you're 21 or older.</p>",
-                    "de": "<p>Es scheint, dass Sie nicht alt genug sind, um bei uns einzukaufen. Kommen Sie wieder, wenn Sie 21 oder älter sind.</p>",
-                    "es": "<p>Parece que no tienes la edad suficiente para comprar en nuestra tienda, vuelve cuando tengas 21 años o más.</p>",
-                    "fr": "<p>On dirait que vous n'êtes pas assez vieux pour faire du shopping avec nous, revenez quand vous aurez 21 ans ou plus.</p>",
-                    "pt-PT": "<p>Parece que não tem idade suficiente para comprar connosco, volte quando tiver 21 anos ou mais.</p>"
-                }
-            },
-            {
-                "type": "text",
-                "id": "deny-button__text",
-                "label": {
-                    "en": "Return button text",
-                    "de": "Rückkehr-Buttontext",
-                    "es": "Texto del botón de retorno",
-                    "fr": "Texte du bouton de retour",
-                    "pt-PT": "Texto do botão de voltar"
-                },
-                "default": {
-                    "en": "Oops, I entered incorrectly",
-                    "de": "<p>Hoppla, meine Eingabe war falsch</p>",
-                    "es": "<p>Uy, me he equivocado</p>",
-                    "fr": "<p>Oups, je me suis trompé</p>",
-                    "pt-PT": "<p>Ups, introduzi incorretamente</p>"
-                }
-            }
-        ]
-    },
-    {
-        "name": {
-            "en": "Popup",
-            "fr": "Pop-up",
-            "de": "Popup",
-            "es": "Emergente",
-            "pt-PT": "Popup"
+        "default": "#ffffff"
+      },
+      {
+        "type": "color",
+        "id": "header-top-bar-color",
+        "label": {
+          "en": "Top bar",
+          "de": "Obere Leiste",
+          "es": "Barra superior",
+          "fr": "Barre supérieure",
+          "pt-PT": "Barra Superior"
         },
-        "settings": [
-            {
-                "type": "checkbox",
-                "id": "popup--enable",
-                "label": {
-                    "en": "Enable popup",
-                    "de": "Aktivieren",
-                    "es": "Habilitar",
-                    "fr": "Activer",
-                    "pt-PT": "Ativar"
-                }
-            },
-            {
-                "type": "checkbox",
-                "id": "popup--test-mode",
-                "label": {
-                    "en": "Enable test mode",
-                    "fr": "Activer le mode test",
-                    "de": "Aktiviere Testmodus",
-                    "es": "Activar modo de prueba",
-                    "pt-PT": "Ativar modo de teste"
-                },
-                "info": {
-                    "en": "Forces the popup to show on every page, and should only be used for editing the popup. Ensure 'Test mode' is disabled when launching your store.",
-                    "fr": "Le mode test impose l’affichage du pop-up sur chaque page et ne doit être utilisé qu’en phase d’édition. Assurez-vous d’avoir désactivé le mode test avant d’ouvrir votre boutique ",
-                    "de": "Testmodus zwingt das Popup auf jeder Seite angezeigt zu werden und sollte nur benutzt werden, um das Popup zu bearbeiten. Stellen Sie sicher, dass 'Testmodus' deaktiviert ist, wenn Sie Ihren Store starten",
-                    "es": "El modo de prueba fuerza la aparición del emergente en todas las páginas, y solo se puede usar para editar el emergente. Asegúrese de que el «Modo de prueba» está desactivado al lanzar la tienda.",
-                    "pt-PT": "O modo de teste obriga o popup a exibir em todas as páginas e só deve ser utilizado para editar o popup. Certifique-se que o 'Modo de teste' está desativado quando lançar a sua loja."
-                }
-            },
-            {
-                "type": "text",
-                "id": "pop-up-text-header-text",
-                "label": {
-                    "en": "Heading",
-                    "de": "Überschrift",
-                    "es": "Encabezado",
-                    "fr": "Rubrique",
-                    "pt-PT": "Título"
-                },
-                "default": {
-                    "en": "Popup",
-                    "fr": "Pop-up",
-                    "de": "Popup",
-                    "es": "Emergente",
-                    "pt-PT": "Popup"
-                }
-            },
-            {
-                "type": "richtext",
-                "id": "pop-up-text-description-text",
-                "label": {
-                    "en": "Text",
-                    "de": "Text",
-                    "es": "Texto",
-                    "fr": "Texte",
-                    "pt-PT": "Texto"
-                },
-                "default": {
-                    "en": "<p>Use this popup to embed a mailing list signup form. Offer incentives to customers to join and build your mailing list.</p>",
-                    "de": "<p>Verwenden Sie dieses Pop-up, um ein Anmeldeformular für den E-Mail-Verteiler einzupflegen. Bieten Sie Kunden Anreize, um sich in Ihren E-Mail-Verteiler einzutragen und diesen aufzubauen.</p>",
-                    "es": "<p>Utilizar esta ventana emergente para insertar un formulario de registro de la lista de correo. Ofrecer incentivos a los clientes para que se unan y se pueda crear la lista de correo.</p>",
-                    "fr": "<p>Utilisez cette fenêtre contextuelle pour intégrer un formulaire d’inscription à une liste de diffusion. Encouragez vos clients à s'inscrire dans votre liste de diffusion et à y contribuer.</p>",
-                    "pt-PT": "<p>Use esta janela para incorporar um formulário de subscrição numa lista de correio. Ofereça incentivos aos clientes para aderirem e construa a sua lista de subscritores.</p>"
-                }
-            },
-            {
-                "type": "image_picker",
-                "id": "popup-newsletter-image",
-                "label": {
-                    "en": "Image",
-                    "de": "Bild",
-                    "es": "Imagen",
-                    "fr": "Image",
-                    "pt-PT": "Imagem"
-                },
-                "info": {
-                    "en": "400 x 400px recommended",
-                    "fr": "400 x 400 px recommandé",
-                    "de": "400 x 400 px empfohlen",
-                    "es": "Se recomienda 400 x 400 px",
-                    "pt-PT": "400 x 400px recomendado"
-                }
-            },
-            {
-                "type": "select",
-                "id": "pop-up-time",
-                "label": {
-                    "en": "Days until popup is displayed again",
-                    "fr": "Jours avant que le pop-up soit de nouveau affiché",
-                    "de": "Tage bis dieses Popup wieder angezeigt wird",
-                    "es": "Días que faltan para que el emergente aparezca nuevamente",
-                    "pt-PT": "Dias até nova exibição da mensagem popup"
-                },
-                "options": [
-                    {
-                        "value": "7",
-                        "label": {
-                            "en": "One week",
-                            "fr": "Une semaine",
-                            "de": "Eine Woche",
-                            "es": "Una semana",
-                            "pt-PT": "Uma semana"
-                        }
-                    },
-                    {
-                        "value": "14",
-                        "label": {
-                            "en": "Two weeks",
-                            "fr": "Deux semaines",
-                            "de": "Zwei Wochen",
-                            "es": "Dos semanas",
-                            "pt-PT": "Duas semanas"
-                        }
-                    },
-                    {
-                        "value": "21",
-                        "label": {
-                            "en": "Three weeks",
-                            "fr": "Trois semaines",
-                            "de": "Drei Wochen",
-                            "es": "Tres semanas",
-                            "pt-PT": "Três semanas"
-                        }
-                    },
-                    {
-                        "value": "28",
-                        "label": {
-                            "en": "Four weeks",
-                            "fr": "Quatre semaines",
-                            "de": "Vier Wochen",
-                            "es": "Cuatro semanas",
-                            "pt-PT": "Quatro semanas"
-                        }
-                    }
-                ],
-                "default": "7"
-            },
-            {
-                "type": "range",
-                "id": "popup-delay",
-                "min": 1,
-                "max": 15,
-                "step": 1,
-                "unit": {
-                    "en": "sec",
-                    "de": "Sek.",
-                    "es": "seg",
-                    "fr": "sec.",
-                    "pt-PT": "seg"
-                },
-                "label": {
-                    "en": "Delay until popup appears",
-                    "fr": "Attendre jusqu’à l’apparition du pop-up",
-                    "de": "Verzögerung bis Popup erscheint",
-                    "es": "Demorar hasta que aparezca el emergente",
-                    "pt-PT": "Adiar até a mensagem popup aparecer"
-                },
-                "default": 5
-            },
-            {
-                "type": "checkbox",
-                "id": "popup--show-social-icons",
-                "label": {
-                    "en": "Enable social icons",
-                    "fr": "Activer les icônes de réseaux sociaux",
-                    "de": "Aktiviere Buttons für Social Media",
-                    "es": "Activar iconos de medios sociales",
-                    "pt-PT": "Ativar ícones sociais"
-                }
-            },
-            {
-                "type": "checkbox",
-                "id": "popup--show-newsletter",
-                "label": {
-                    "en": "Enable newsletter signup",
-                    "fr": "Activer l’inscription à une newsletter",
-                    "de": "Aktiviere Newsletter-Anmeldung",
-                    "es": "Activar la subscripción al boletín de noticias",
-                    "pt-PT": "Ativar subscrição da newsletter"
-                },
-                "default": true
-            }
-        ]
-    },
-    {
-        "name": {
-            "en": "Favicon",
-            "fr": "Favicon",
-            "de": "Favicon",
-            "es": "Favicón",
-            "pt-PT": "Favicon"
+        "default": "#F3F3F3"
+      },
+      {
+        "type": "color",
+        "id": "header-text-color",
+        "label": {
+          "en": "Text",
+          "de": "Text",
+          "es": "Texto",
+          "fr": "Texte",
+          "pt-PT": "Texto"
         },
-        "settings": [
-            {
-                "type": "image_picker",
-                "id": "favicon",
-                "label": {
-                    "en": "Favicon image",
-                    "fr": "Image de favicon",
-                    "de": "Favicon-Bild",
-                    "es": "Imagen del favicón",
-                    "pt-PT": "Imagem do favicon"
-                },
-                "info": {
-                    "en": "Will be scaled down to 32 x 32px",
-                    "fr": "Sera réduit en 32 x 32 px",
-                    "de": "Wird herunterskaliert auf 32 x 32 px.",
-                    "es": "Se reducirá a 32 x 32 px",
-                    "pt-PT": "Será reduzido para 32 x 32px"
-                }
-            }
-        ]
-    },
-    {
-        "name": {
-            "en": "Search",
-            "fr": "Recherche",
-            "de": "Suche",
-            "es": "Búsqueda",
-            "pt-PT": "Pesquisar"
+        "default": "#333333"
+      },
+      {
+        "type": "color",
+        "id": "header-overlay-text-color",
+        "label": {
+          "en": "Overlay text",
+          "de": "Überlagerter Text",
+          "es": "Texto superpuesto",
+          "fr": "Texte en superposition",
+          "pt-PT": "Sobrepor Texto"
         },
-        "settings": [
-            {
-                "type": "checkbox",
-                "id": "predictive_search_enabled",
-                "label": {
-                    "en": "Enable predictive search",
-                    "de": "Prädiktive Suche aktivieren",
-                    "es": "Habilitar búsqueda predictiva",
-                    "fr": "Activer la recherche prédictive",
-                    "pt-PT": "Ativar pesquisa preditiva"
-                },
-                "default": true
-            },
-            {
-                "type": "header",
-                "content": {
-                    "en": "Search includes",
-                    "de": "Die Suche beinhaltet",
-                    "es": "La búsqueda incluye",
-                    "fr": "La recherche inclus",
-                    "pt-PT": "A pesquisa inclui"
-                }
-            },
-            {
-                "type": "checkbox",
-                "id": "enable-product-results",
-                "label": {
-                    "en": "Products",
-                    "de": "Produkte",
-                    "es": "Productos",
-                    "fr": "Produits",
-                    "pt-PT": "Produtos"
-                },
-                "default": true
-            },
-            {
-                "type": "checkbox",
-                "id": "enable-page-results",
-                "label": {
-                    "en": "Pages",
-                    "de": "Seiten",
-                    "es": "Páginas",
-                    "fr": "Pages",
-                    "pt-PT": "Páginas"
-                },
-                "default": false
-            },
-            {
-                "type": "checkbox",
-                "id": "enable-article-results",
-                "label": {
-                    "en": "Articles",
-                    "de": "Artikel",
-                    "es": "Artículos",
-                    "fr": "Des articles",
-                    "pt-PT": "Artigos"
-                },
-                "default": false
-            },
-            {
-                "type": "checkbox",
-                "id": "enable-collection-results",
-                "label": {
-                    "en": "Collections",
-                    "de": "Sammlungen",
-                    "es": "Colecciones",
-                    "fr": "Les collections",
-                    "pt-PT": "Coleções"
-                },
-                "default": false,
-                "info": {
-                    "en": "Only available in predictive search",
-                    "de": "Nur bei der prädiktiven Suche verfügbar",
-                    "es": "Disponible solo en la búsqueda predictiva.",
-                    "fr": "Disponible uniquement en recherche prédictive",
-                    "pt-PT": "Disponível apenas na pesquisa preditiva"
-                }
-            },
-            {
-                "type": "header",
-                "content": {
-                    "en": "Products",
-                    "de": "Produkte",
-                    "es": "Productos",
-                    "fr": "Des produits",
-                    "pt-PT": "Produtos"
-                }
-            },
-            {
-                "type": "checkbox",
-                "id": "predictive_search_show_vendor",
-                "label": {
-                    "en": "Show vendor",
-                    "de": "Verkäufer anzeigen",
-                    "es": "Mostrar vendedor",
-                    "fr": "Afficher le vendeur",
-                    "pt-PT": "Mostrar vendedor"
-                },
-                "default": false,
-                "info": {
-                    "en": "Only available in predictive search",
-                    "de": "Nur bei der prädiktiven Suche verfügbar",
-                    "es": "Disponible solo en la búsqueda predictiva.",
-                    "fr": "Disponible uniquement en recherche prédictive",
-                    "pt-PT": "Disponível apenas na pesquisa preditiva"
-                }
-            },
-            {
-                "type": "checkbox",
-                "id": "predictive_search_show_price",
-                "label": {
-                    "en": "Show price",
-                    "de": "Preis anzeigen",
-                    "es": "Mostrar precio",
-                    "fr": "Afficher le prix",
-                    "pt-PT": "Mostrar preço"
-                },
-                "default": false,
-                "info": {
-                    "en": "Only available in predictive search",
-                    "de": "Nur bei der prädiktiven Suche verfügbar",
-                    "es": "Disponible solo en la búsqueda predictiva.",
-                    "fr": "Disponible uniquement en recherche prédictive",
-                    "pt-PT": "Disponível apenas na pesquisa preditiva"
-                }
-            }
-        ]
+        "default": "#ffffff"
+      },
+      {
+        "type": "header",
+        "content": {
+          "en": "Sticky header",
+          "fr": "En-tête fixe",
+          "de": "Sticky Header",
+          "es": "Encabezado adhesivo",
+          "pt-PT": "Cabeçalho adesivo"
+        }
+      },
+      {
+        "type": "color",
+        "id": "sticky-header-background-color",
+        "label": {
+          "en": "Background",
+          "de": "Hintergrund",
+          "es": "Fondo",
+          "fr": "Contexte général",
+          "pt-PT": "Fundo"
+        },
+        "default": "#ffffff"
+      },
+      {
+        "type": "color",
+        "id": "sticky-header-top-bar-color",
+        "label": {
+          "en": "Top bar",
+          "de": "Obere Leiste",
+          "es": "Barra superior",
+          "fr": "Barre supérieure",
+          "pt-PT": "Barra Superior"
+        },
+        "default": "#F3F3F3"
+      },
+      {
+        "type": "color",
+        "id": "sticky-header-text-color",
+        "label": {
+          "en": "Text",
+          "de": "Text",
+          "es": "Texto",
+          "fr": "Texte",
+          "pt-PT": "Texto"
+        },
+        "default": "#000000"
+      },
+      {
+        "type": "header",
+        "content": {
+          "en": "Mobile navigation",
+          "de": "Mobile Navigation",
+          "es": "Navegación móvil",
+          "fr": "Navigation mobile",
+          "pt-PT": "Navegação móvel"
+        }
+      },
+      {
+        "type": "color",
+        "id": "sidebar-navigation--background-color",
+        "label": {
+          "en": "Background",
+          "de": "Hintergrund",
+          "es": "Fondo",
+          "fr": "Contexte général",
+          "pt-PT": "Fundo"
+        },
+        "default": "#222222"
+      },
+      {
+        "type": "color",
+        "id": "sidebar-navigation--text-color",
+        "label": {
+          "en": "Text",
+          "de": "Text",
+          "es": "Texto",
+          "fr": "Texte",
+          "pt-PT": "Texto"
+        },
+        "default": "#ffffff"
+      },
+      {
+        "type": "header",
+        "content": {
+          "en": "Footer",
+          "de": "Fußzeile",
+          "es": "Pie de página",
+          "fr": "Pied de page",
+          "pt-PT": "Rodapé"
+        }
+      },
+      {
+        "type": "color",
+        "id": "footer-background-color",
+        "label": {
+          "en": "Background",
+          "de": "Hintergrund",
+          "es": "Fondo",
+          "fr": "Contexte général",
+          "pt-PT": "Fundo"
+        },
+        "default": "#ebebeb"
+      },
+      {
+        "type": "color",
+        "id": "footer-text-color",
+        "label": {
+          "en": "Text",
+          "de": "Text",
+          "es": "Texto",
+          "fr": "Texte",
+          "pt-PT": "Texto"
+        },
+        "default": "#333333"
+      },
+      {
+        "type": "header",
+        "content": {
+          "en": "Buttons",
+          "fr": "Boutons",
+          "de": "Buttons",
+          "es": "Botones",
+          "pt-PT": "Botões"
+        }
+      },
+      {
+        "type": "color",
+        "id": "add-to-cart-background-color",
+        "label": {
+          "en": "Background",
+          "de": "Hintergrund",
+          "es": "Fondo",
+          "fr": "Contexte général",
+          "pt-PT": "Fundo"
+        },
+        "default": "#212121"
+      },
+      {
+        "type": "color",
+        "id": "add-to-cart-background-hover-color",
+        "label": {
+          "en": "Background hover",
+          "fr": "Fond flottant",
+          "de": "Hintergrund-Hover",
+          "es": "Fondo con función «hover»",
+          "pt-PT": "Passar o cursor sobre o fundo"
+        },
+        "default": "#000000"
+      },
+      {
+        "type": "color",
+        "id": "add-to-cart-text-color",
+        "label": {
+          "en": "Text",
+          "de": "Text",
+          "es": "Texto",
+          "fr": "Texte",
+          "pt-PT": "Texto"
+        },
+        "default": "#fff"
+      },
+      {
+        "type": "header",
+        "content": {
+          "en": "Popup",
+          "fr": "Pop-up",
+          "de": "Popup",
+          "es": "Emergente",
+          "pt-PT": "Popup"
+        }
+      },
+      {
+        "type": "color",
+        "id": "pop-up-background-color",
+        "label": {
+          "en": "Background",
+          "de": "Hintergrund",
+          "es": "Fondo",
+          "fr": "Contexte général",
+          "pt-PT": "Fundo"
+        },
+        "default": "#333333"
+      },
+      {
+        "type": "color",
+        "id": "pop-up-text-color",
+        "label": {
+          "en": "Text",
+          "de": "Text",
+          "es": "Texto",
+          "fr": "Texte",
+          "pt-PT": "Texto"
+        },
+        "default": "#fff"
+      },
+      {
+        "type": "header",
+        "content": {
+          "en": "Image overlays",
+          "fr": "Recouvrements d’images ",
+          "de": "Bild-Overlay",
+          "es": "Superposiciones de imagen",
+          "pt-PT": "Sobreposições de imagem"
+        }
+      },
+      {
+        "type": "color",
+        "id": "color_image_overlay_text",
+        "label": {
+          "en": "Text",
+          "de": "Text",
+          "es": "Texto",
+          "fr": "Texte",
+          "pt-PT": "Texto"
+        },
+        "default": "#fff"
+      },
+      {
+        "type": "color",
+        "id": "color_image_overlay",
+        "label": {
+          "en": "Fade",
+          "de": "Ausblenden",
+          "es": "Desvanecerse",
+          "fr": "Fondu",
+          "pt-PT": "Desvanecer"
+        },
+        "default": "#000"
+      },
+      {
+        "type": "range",
+        "id": "image_overlay_opacity",
+        "min": 0,
+        "max": 95,
+        "step": 5,
+        "unit": {
+          "en": "%",
+          "de": "%",
+          "es": "%",
+          "fr": "%",
+          "pt-PT": "%"
+        },
+        "label": {
+          "en": "Overlay opacity",
+          "de": "Überlagerungsdeckkraft",
+          "es": "Capacidad de sobrexposición",
+          "fr": "Opacité de superposition",
+          "pt-PT": "Opacidade de sobreposição"
+        },
+        "default": 60
+      },
+      {
+        "type": "header",
+        "content": {
+          "en": "Sale badge",
+          "fr": "Badge « En solde »",
+          "de": "Sale-Button",
+          "es": "Cartel de «oferta»",
+          "pt-PT": "Emblema de venda"
+        }
+      },
+      {
+        "type": "color",
+        "id": "sale-label-color",
+        "label": {
+          "en": "Background",
+          "de": "Hintergrund",
+          "es": "Fondo",
+          "fr": "Contexte général",
+          "pt-PT": "Fundo"
+        },
+        "default": "#D62426"
+      },
+      {
+        "type": "color",
+        "id": "sale-label-text-color",
+        "label": {
+          "en": "Text",
+          "de": "Text",
+          "es": "Texto",
+          "fr": "Texte",
+          "pt-PT": "Texto"
+        },
+        "default": "#ffffff"
+      },
+      {
+        "type": "header",
+        "content": {
+          "en": "Sold out badge",
+          "de": "Ausverkauft-Button",
+          "es": "Cartel de «agotado»",
+          "fr": "Badge « Épuisé »",
+          "pt-PT": "Emblema de esgotado"
+        }
+      },
+      {
+        "type": "color",
+        "id": "sold-out-badge-color",
+        "label": {
+          "en": "Background",
+          "de": "Hintergrund",
+          "es": "Fondo",
+          "fr": "Contexte général",
+          "pt-PT": "Fundo"
+        },
+        "default": "#000000"
+      },
+      {
+        "type": "color",
+        "id": "sold-out-badge-text-color",
+        "label": {
+          "en": "Text",
+          "de": "Text",
+          "es": "Texto",
+          "fr": "Texte",
+          "pt-PT": "Texto"
+        },
+        "default": "#ffffff"
+      },
+      {
+        "type": "checkbox",
+        "id": "sold_out_badge",
+        "label": {
+          "en": "Show sold out badge",
+          "de": "Markierung für Ausverkauft anzeigen",
+          "es": "Mostrar el distintivo de agotado",
+          "fr": "Afficher le badge \"épuisé\"",
+          "pt-PT": "Mostrar Crachá de Esgotado"
+        },
+        "default": true
+      },
+      {
+        "type": "header",
+        "content": {
+          "en": "Free shipping banner",
+          "de": "Banner für kostenlosen Versand",
+          "es": "Anuncio de envío gratis",
+          "fr": "Bannière de livraison gratuite",
+          "pt-PT": "'Banner' de envio gratuito"
+        }
+      },
+      {
+        "type": "color",
+        "id": "free-shipping-background-color",
+        "label": {
+          "en": "Background",
+          "de": "Hintergrund",
+          "es": "Fondo",
+          "fr": "Contexte général",
+          "pt-PT": "Fundo"
+        },
+        "default": "#BEBEBE"
+      },
+      {
+        "type": "color",
+        "id": "free-shipping-text-color",
+        "label": {
+          "en": "Text",
+          "de": "Text",
+          "es": "Texto",
+          "fr": "Texte",
+          "pt-PT": "Texto"
+        },
+        "default": "#000000"
+      }
+    ]
+  },
+  {
+    "name": {
+      "en": "Typography",
+      "fr": "Typographie",
+      "de": "Typographie",
+      "es": "Tipografía",
+      "pt-PT": "Tipografia"
     },
-    {
-        "name": "Free delivery promotion",
-        "settings": [
-            {
-                "type": "checkbox",
-                "id": "enable_free_delivery_promo",
-                "label": "Enable free delivery promotion",
-                "default": false
-            },
-            {
-                "type": "number",
-                "id": "free_delivery_threshold",
-                "label": "Free delivery threshold",
-                "default": 21
-            },
-            {
-                "type": "text",
-                "id": "free_delivery_locked_message",
-                "label": "Locked message",
-                "default": "Add {remaining} more meals to unlock free delivery."
-            },
-            {
-                "type": "text",
-                "id": "free_delivery_unlocked_message",
-                "label": "Unlocked message",
-                "default": "You've unlocked free delivery."
-            },
-            {
-              "type": "text",
-              "id": "free_delivery_discount_code",
-              "label": "Discount code (optional)"
-            },
-            {
-                "type": "text",
-                "id": "announcement_default_text",
-                "label": "Announcement bar text when promo off",
-                "default": "USDA Certified • Serving the lower 48"
-            },
-            {
-                "type": "text",
-                "id": "announcement_promo_text",
-                "label": "Announcement bar text when promo on",
-                "default": "Stock up on ICON Meals!"
+    "settings": [
+      {
+        "type": "header",
+        "content": {
+          "en": "Headings",
+          "fr": "Titres",
+          "de": "Headings",
+          "es": "Encabezados",
+          "pt-PT": "Cabeçalhos"
+        }
+      },
+      {
+        "type": "font_picker",
+        "id": "type_header_font",
+        "label": {
+          "en": "Font",
+          "fr": "Police",
+          "de": "Schriftart",
+          "es": "Tipografía",
+          "pt-PT": "Tipo de letra"
+        },
+        "default": "montserrat_n5"
+      },
+      {
+        "type": "select",
+        "id": "heading-case",
+        "label": {
+          "en": "Heading case",
+          "fr": "Casse de titre",
+          "de": "Titelgröße",
+          "es": "Formato del encabezado",
+          "pt-PT": "Caixa do cabeçalho"
+        },
+        "default": "none",
+        "options": [
+          {
+            "value": "none",
+            "label": {
+              "en": "Normal case",
+              "fr": "Casse normale",
+              "de": "Normale Größe",
+              "es": "Formato normal",
+              "pt-PT": "Caixa normal"
             }
+          },
+          {
+            "value": "lowercase",
+            "label": {
+              "en": "Lowercase",
+              "fr": "Minuscules",
+              "de": "Kleinschrift",
+              "es": "Minúscula",
+              "pt-PT": "Letra minúscula"
+            }
+          },
+          {
+            "value": "uppercase",
+            "label": {
+              "en": "Uppercase",
+              "fr": "Majuscules",
+              "de": "Großschrift",
+              "es": "Mayúscula",
+              "pt-PT": "Letra maiúscula"
+            }
+          }
         ]
-    }
+      },
+      {
+        "type": "select",
+        "id": "heading--base-size",
+        "label": {
+          "en": "Size",
+          "fr": "Taille",
+          "de": "Größe",
+          "es": "Tamaño",
+          "pt-PT": "Tamanho"
+        },
+        "options": [
+          {
+            "value": "small",
+            "label": {
+              "en": "Small",
+              "de": "Klein",
+              "es": "Pequeño",
+              "fr": "Petite",
+              "pt-PT": "Pequeno"
+            }
+          },
+          {
+            "value": "normal",
+            "label": {
+              "en": "Normal",
+              "de": "Normal",
+              "es": "Normal",
+              "fr": "Normal",
+              "pt-PT": "Normal"
+            }
+          },
+          {
+            "value": "large",
+            "label": {
+              "en": "Large",
+              "de": "Groß",
+              "es": "Grande",
+              "fr": "Grande",
+              "pt-PT": "Grande"
+            }
+          }
+        ]
+      },
+      {
+        "type": "header",
+        "content": {
+          "en": "Subheadings",
+          "de": "Unterüberschrift",
+          "es": "Subencabezado",
+          "fr": "Sous-rubrique",
+          "pt-PT": "Subtítulo"
+        }
+      },
+      {
+        "type": "font_picker",
+        "id": "subheading--font",
+        "label": {
+          "en": "Font",
+          "fr": "Police",
+          "de": "Schriftart",
+          "es": "Tipografía",
+          "pt-PT": "Tipo de letra"
+        },
+        "default": "roboto_n4"
+      },
+      {
+        "type": "select",
+        "id": "subheading--case",
+        "label": {
+          "en": "Subheading case",
+          "fr": "Casse de la sous-rubrique",
+          "de": "Unterüberschrift Groß-/Kleinschreibung",
+          "es": "Mayúsculas de subtítulos",
+          "pt-PT": "Caixa de sub-título"
+        },
+        "default": "uppercase",
+        "options": [
+          {
+            "value": "none",
+            "label": {
+              "en": "Normal case",
+              "fr": "Casse normale",
+              "de": "Normale Größe",
+              "es": "Formato normal",
+              "pt-PT": "Caixa normal"
+            }
+          },
+          {
+            "value": "lowercase",
+            "label": {
+              "en": "Lowercase",
+              "fr": "Minuscules",
+              "de": "Kleinschrift",
+              "es": "Minúscula",
+              "pt-PT": "Letra minúscula"
+            }
+          },
+          {
+            "value": "uppercase",
+            "label": {
+              "en": "Uppercase",
+              "fr": "Majuscules",
+              "de": "Großschrift",
+              "es": "Mayúscula",
+              "pt-PT": "Letra maiúscula"
+            }
+          }
+        ]
+      },
+      {
+        "type": "header",
+        "content": {
+          "en": "Body text",
+          "fr": "Corps de texte",
+          "de": "Textkörper",
+          "es": "Texto principal",
+          "pt-PT": "Corpo de texto"
+        }
+      },
+      {
+        "type": "font_picker",
+        "id": "type_base_font",
+        "label": {
+          "en": "Font",
+          "fr": "Police",
+          "de": "Schriftart",
+          "es": "Tipografía",
+          "pt-PT": "Tipo de letra"
+        },
+        "default": "work_sans_n4"
+      },
+      {
+        "type": "range",
+        "id": "typography-body-font-size",
+        "min": 12,
+        "max": 22,
+        "step": 1,
+        "unit": {
+          "en": "px",
+          "de": "px",
+          "es": "px",
+          "fr": "px",
+          "pt-PT": "px"
+        },
+        "label": {
+          "en": "Base size",
+          "fr": "Taille de base",
+          "de": "Basisgröße",
+          "es": "Tamaño base",
+          "pt-PT": "Tamanho base"
+        },
+        "default": 14
+      },
+      {
+        "type": "header",
+        "content": {
+          "en": "Navigation",
+          "de": "Navigation",
+          "es": "Navegación",
+          "fr": "Navigation",
+          "pt-PT": "Navegação"
+        }
+      },
+      {
+        "type": "select",
+        "id": "navigation--font",
+        "label": {
+          "en": "Font",
+          "fr": "Police",
+          "de": "Schriftart",
+          "es": "Tipografía",
+          "pt-PT": "Tipo de letra"
+        },
+        "default": "body",
+        "options": [
+          {
+            "value": "body",
+            "label": {
+              "en": "Body",
+              "de": "Textkörper",
+              "es": "Texto principal",
+              "fr": "Corps de texte",
+              "pt-PT": "Corpo de texto"
+            }
+          },
+          {
+            "value": "subheading",
+            "label": {
+              "en": "Subheading",
+              "de": "Unterüberschrift",
+              "es": "Subencabezado",
+              "fr": "Sous-rubrique",
+              "pt-PT": "Subtítulo"
+            }
+          }
+        ]
+      },
+      {
+        "type": "checkbox",
+        "id": "navigation--capitalize",
+        "label": {
+          "en": "Capitalize navigation",
+          "de": "Navigation groß schreiben",
+          "es": "Navegación en mayúsculas",
+          "fr": "Mettre la navigation en majuscules",
+          "pt-PT": "Capitalize navegação"
+        },
+        "default": true
+      },
+      {
+        "type": "header",
+        "content": {
+          "en": "Buttons",
+          "fr": "Boutons",
+          "de": "Buttons",
+          "es": "Botones",
+          "pt-PT": "Botões"
+        }
+      },
+      {
+        "type": "select",
+        "id": "buttons--font",
+        "label": {
+          "en": "Font",
+          "fr": "Police",
+          "de": "Schriftart",
+          "es": "Tipografía",
+          "pt-PT": "Tipo de letra"
+        },
+        "default": "body",
+        "options": [
+          {
+            "value": "body",
+            "label": {
+              "en": "Body",
+              "de": "Textkörper",
+              "es": "Texto principal",
+              "fr": "Corps de texte",
+              "pt-PT": "Corpo de texto"
+            }
+          },
+          {
+            "value": "subheading",
+            "label": {
+              "en": "Subheading",
+              "de": "Unterüberschrift",
+              "es": "Subencabezado",
+              "fr": "Sous-rubrique",
+              "pt-PT": "Subtítulo"
+            }
+          }
+        ]
+      },
+      {
+        "type": "range",
+        "id": "typography-buttons-font-size",
+        "min": 12,
+        "max": 18,
+        "step": 1,
+        "unit": {
+          "en": "px",
+          "de": "px",
+          "es": "px",
+          "fr": "px",
+          "pt-PT": "px"
+        },
+        "label": {
+          "en": "Size",
+          "fr": "Taille",
+          "de": "Größe",
+          "es": "Tamaño",
+          "pt-PT": "Tamanho"
+        },
+        "default": 14
+      },
+      {
+        "type": "checkbox",
+        "id": "buttons--capitalize",
+        "label": {
+          "en": "Capitalize buttons",
+          "de": "Schaltflächen groß schreiben",
+          "es": "Botones en mayúsculas",
+          "fr": "Mettre les boutons en majuscules",
+          "pt-PT": "Capitalize os botões"
+        },
+        "default": true
+      }
+    ]
+  },
+  {
+    "name": {
+      "en": "Cart",
+      "fr": "Panier",
+      "de": "Einkaufswagen",
+      "es": "Carrito",
+      "pt-PT": "Carrinho"
+    },
+    "settings": [
+      {
+        "type": "header",
+        "content": {
+          "en": "Cart",
+          "fr": "Panier",
+          "de": "Einkaufswagen",
+          "es": "Carrito",
+          "pt-PT": "Carrinho"
+        }
+      },
+      {
+        "type": "select",
+        "id": "cart-type",
+        "label": {
+          "en": "Cart type",
+          "fr": "Type de panier",
+          "de": "Einkaufswagenart",
+          "es": "Tipo de carrito",
+          "pt-PT": "Tipo de carrinho"
+        },
+        "options": [
+          {
+            "value": "drawer",
+            "label": {
+              "en": "Drawer",
+              "fr": "Tiroir",
+              "de": "Schublade",
+              "es": "Cajón",
+              "pt-PT": "Gaveta"
+            }
+          },
+          {
+            "value": "persistent",
+            "label": {
+              "en": "Fixed",
+              "de": "Festgestellt",
+              "es": "Fijo",
+              "fr": "Fixe",
+              "pt-PT": "Fixo"
+            }
+          },
+          {
+            "value": "page",
+            "label": {
+              "en": "Page",
+              "de": "Seite",
+              "es": "Página",
+              "fr": "Page",
+              "pt-PT": "Página"
+            }
+          }
+        ],
+        "default": "page"
+      },
+      {
+        "type": "radio",
+        "id": "cart-action",
+        "label": {
+          "en": "Add to Cart action",
+          "de": "Aktion „Zum Einkaufswagen hinzufügen“",
+          "es": "Acción de Añadir al carrito",
+          "fr": "Action d'ajout au panier",
+          "pt-PT": "Ação Adicionar ao Carrinho"
+        },
+        "options": [
+          {
+            "value": "added",
+            "label": {
+              "en": "Show 'Added' message",
+              "de": "„Hinzugefügt“-Mitteilung zeigen",
+              "es": "Mostar el mensaje de «Añadido»",
+              "fr": "Afficher le message « Ajouté »",
+              "pt-PT": "Mostrar mensagem \"Adicionado\""
+            }
+          },
+          {
+            "value": "cart",
+            "label": {
+              "en": "Go to cart",
+              "de": "Zum Einkaufswagen gehen",
+              "es": "Ir al carrito",
+              "fr": "Aller au panier",
+              "pt-PT": "Ir para o carrinho"
+            }
+          }
+        ],
+        "default": "cart"
+      },
+      {
+        "type": "checkbox",
+        "id": "enable-additional-checkout-buttons",
+        "label": {
+          "en": "Enable dynamic checkout buttons",
+          "de": "Dynamische Checkout-Buttons aktivieren",
+          "es": "Habilitar los botones de compra dinámica",
+          "fr": "Activer les boutons de caisse dynamiques",
+          "pt-PT": "Ativar botões de checkout dinâmicos"
+        },
+        "info": {
+          "en": "[Learn more](https://help.shopify.com/en/manual/sell-online/online-store/dynamic-checkout)",
+          "de": "[Mehr erfahren](https://help.shopify.com/en/manual/sell-online/online-store/dynamic-checkout)",
+          "es": "[Aprenda más](https://help.shopify.com/en/manual/sell-online/online-store/dynamic-checkout)",
+          "fr": "[En savoir plus](https://help.shopify.com/en/manual/sell-online/online-store/dynamic-checkout)",
+          "pt-PT": "[Saber mais](https://help.shopify.com/en/manual/sell-online/online-store/dynamic-checkout)"
+        },
+        "default": true
+      },
+      {
+        "type": "checkbox",
+        "id": "allow_note",
+        "label": {
+          "en": "Enable cart notes",
+          "fr": "Activer les commentaires du panier",
+          "de": "Aktiviere Einkaufswagen-Notizen",
+          "es": "Activar comentarios en carrito",
+          "pt-PT": "Ativar notas de carrinho"
+        },
+        "default": false
+      },
+      {
+        "type": "header",
+        "content": {
+          "en": "Fixed cart",
+          "fr": "Panier fixe",
+          "de": "Fester Warenkorb",
+          "es": "Carro fijo",
+          "pt-PT": "Carrinho de compras fixo"
+        }
+      },
+      {
+        "type": "select",
+        "id": "persistent-cart-visibility",
+        "label": {
+          "en": "Visibility",
+          "de": "Sichtbarkeit",
+          "es": "Visibilidad",
+          "fr": "Visibilité",
+          "pt-PT": "Visibilidade"
+        },
+        "options": [
+          {
+            "value": "all_pages",
+            "label": {
+              "en": "All pages",
+              "de": "Alle Seiten",
+              "es": "Todas las páginas",
+              "fr": "Toutes les pages",
+              "pt-PT": "Todas as páginas"
+            }
+          },
+          {
+            "value": "product_collection",
+            "label": {
+              "en": "Product and collection pages only",
+              "de": "Nur Produkt- und Kollektionsseiten",
+              "es": "Solo páginas de productos y colecciones",
+              "fr": "Pages de produits et de collections uniquement",
+              "pt-PT": "Apenas páginas de produtos e coleções"
+            }
+          }
+        ]
+      },
+      {
+        "type": "header",
+        "content": {
+          "en": "Encouragement",
+          "fr": "Encouragement",
+          "de": "Ermutigung",
+          "es": "Estímulo",
+          "pt-PT": "Encorajamento"
+        }
+      },
+      {
+        "type": "checkbox",
+        "id": "enable_shipping_encouragement",
+        "label": {
+          "en": "Enable free shipping encouragement",
+          "fr": "Activer l'encouragement à la livraison gratuite",
+          "de": "Ermöglichung des kostenlosen Versands Ermutigung",
+          "es": "Habilitar el estímulo para el envío gratuito",
+          "pt-PT": "Ativar o incentivo ao envio gratuito"
+        },
+        "default": true
+      },
+      {
+        "type": "text",
+        "id": "free_shipping_message",
+        "label": {
+          "en": "Free shipping message",
+          "fr": "Message de livraison gratuite",
+          "de": "Kostenlose Versandnachricht",
+          "es": "Mensaje de envío gratis",
+          "pt-PT": "Mensagem de envio gratuito"
+        },
+        "info": {
+          "en": "Please ensure the <price> placeholder remains in your text",
+          "fr": "Veuillez vous assurer que l'espace réservé <price> reste dans votre texte",
+          "de": "Bitte stellen Sie sicher, dass der <price>-Platzhalter in Ihrem Text bleibt",
+          "es": "Asegúrese de que el marcador de posición <price> permanece en su texto",
+          "pt-PT": "Assegure-se de que o <price>'placeholder' permanece no seu texto"
+        },
+        "default": {
+          "en": "Spend <price> more and get free shipping!",
+          "fr": "Dépensez <price> de plus et bénéficiez de la livraison gratuite !",
+          "de": "Geben Sie <price> mehr aus und erhalten Sie kostenlosen Versand!",
+          "es": "Gaste más de <price> y obtenga envíos gratis",
+          "pt-PT": "Gaste <price> mais e obtenha envio gratuito!"
+        }
+      },
+      {
+        "type": "text",
+        "id": "free_shipping_achieved",
+        "label": {
+          "en": "Free shipping achieved message",
+          "fr": "Message de livraison gratuite réalisée",
+          "de": "Kostenloser Versand erreicht Nachricht",
+          "es": "Mensaje de envío gratis logrado",
+          "pt-PT": "Mensagem de obtenção de envio gratuito"
+        },
+        "default": {
+          "en": "Your cart qualifies for free shipping!",
+          "fr": "Votre panier remplit les conditions requises pour la livraison gratuite !",
+          "de": "Ihr Warenkorb ist für kostenlosen Versand qualifiziert!",
+          "es": "¡Su carrito cumple los requisitos para tener envío gratuito!",
+          "pt-PT": "O seu carrinho tem direito a envio gratuito!"
+        }
+      },
+      {
+        "type": "text",
+        "id": "free_shipping_amount",
+        "label": {
+          "en": "Free shipping when cart total is equal or larger than: ",
+          "de": "Kostenloser Versand, wenn die Warenkorbsumme gleich oder größer als ist:",
+          "es": "Envío gratis cuando el total del carrito sea igual o mayor que:",
+          "fr": "Livraison gratuite lorsque le total du panier est égal ou supérieur à :",
+          "pt-PT": "Envio gratuito quando o total do carrinho for igual ou maior do que:"
+        },
+        "default": {
+          "en": "30.00",
+          "de": "30.00",
+          "es": "30.00",
+          "fr": "30.00",
+          "pt-PT": "30.00"
+        }
+      }
+    ]
+  },
+  {
+    "name": {
+      "en": "Products",
+      "fr": "Produits",
+      "de": "Produkte",
+      "es": "Productos",
+      "pt-PT": "Produtos"
+    },
+    "settings": [
+      {
+        "type": "checkbox",
+        "id": "show_sale_price",
+        "label": {
+          "en": "Show sale price",
+          "de": "Verkaufspreis anzeigen",
+          "es": "Mostrar precio de oferta",
+          "fr": "Afficher le prix de vente",
+          "pt-PT": "Mostrar preço de venda"
+        },
+        "default": true
+      },
+      {
+        "type": "checkbox",
+        "id": "show_sale_badge",
+        "label": {
+          "en": "Show sale badge",
+          "de": "Markierung für Aktionen anzeigen",
+          "es": "Mostrar el distintivo de en venta",
+          "fr": "Afficher le badge \"en vente\"",
+          "pt-PT": "Mostrar Crachá de Venda"
+        },
+        "default": true
+      },
+      {
+        "type": "checkbox",
+        "id": "enable_store_pickup",
+        "label": {
+          "en": "Show local pickup",
+          "de": "Örtliche Abholung anzeigen",
+          "es": "Mostrar recogida local",
+          "fr": "Afficher le ramassage local",
+          "pt-PT": "Mostrar a recolha local"
+        },
+        "info": {
+          "en": "You will need to set your pickup locations to enable. [Learn more](https://help.shopify.com/en/manual/locations)",
+          "de": "Sie müssen zum Aktivieren Ihre örtlichen Abholstellen festlegen. [Mehr erfahren](https://help.shopify.com/de/manual/locations)",
+          "es": "Deberás configurar los lugares de recogida para habilitarlo. [Más información](https://help.shopify.com/es/manual/locations)",
+          "fr": "Vous devrez définir vos lieux de ramassage pour activer. [En savoir plus](https://help.shopify.com/fr/manual/locations)",
+          "pt-PT": "Precisará de definir as suas localizações de recolha para ativar. [Saber mais](https://help.shopify.com/pt-PT/manual/locations)"
+        },
+        "default": true
+      },
+      {
+        "type": "header",
+        "content": {
+          "en": "Product grids",
+          "de": "Produktgitter",
+          "es": "Tablas de productos",
+          "fr": "Grilles de produits",
+          "pt-PT": "Grelhas de produtos"
+        }
+      },
+      {
+        "type": "select",
+        "id": "product-grid",
+        "label": {
+          "en": "Grid image size",
+          "fr": "Taille de l'image de la grille",
+          "de": "Rasterbildgröße",
+          "es": "Tamaño de imagen de la cuadrícula",
+          "pt-PT": "Tamanho das imagens da grelha"
+        },
+        "default": "natural",
+        "options": [
+          {
+            "value": "natural",
+            "label": {
+              "en": "Natural",
+              "fr": "Naturel",
+              "de": "Natürlich",
+              "es": "Natural",
+              "pt-PT": "Natural"
+            }
+          },
+          {
+            "value": "square",
+            "label": {
+              "en": "Square (1:1)",
+              "fr": "Carré (1: 1)",
+              "de": "Quadrat (1:1)",
+              "es": "Cuadrado (1:1)",
+              "pt-PT": "Quadrado (1:1)"
+            }
+          },
+          {
+            "value": "tall",
+            "label": {
+              "en": "Tall (2:3)",
+              "fr": "Grand (2: 3)",
+              "de": "Groß (2:3)",
+              "es": "Vertical (2:3)",
+              "pt-PT": "Estreito (2:3)"
+            }
+          },
+          {
+            "value": "wide",
+            "label": {
+              "en": "Wide (4:3)",
+              "fr": "Large (4: 3)",
+              "de": "Weit (4:3)",
+              "es": "Ancho (4:3)",
+              "pt-PT": "Largo (4:3)"
+            }
+          }
+        ]
+      },
+      {
+        "type": "checkbox",
+        "id": "product_padding_enable",
+        "label": {
+          "en": "Image padding",
+          "de": "Image-Padding",
+          "es": "Relleno de imagen",
+          "fr": "Remplissage d'image",
+          "pt-PT": "Revestimento de imagem"
+        },
+        "default": false
+      },
+      {
+        "type": "checkbox",
+        "id": "center_align",
+        "label": {
+          "en": "Center align product text",
+          "de": "Produkttext zentriert ausrichten",
+          "es": "Alinear el texto del producto en el centro",
+          "fr": "Centrer le texte du produit",
+          "pt-PT": "Alinhar o texto do produto ao centro"
+        },
+        "default": false
+      },
+      {
+        "type": "checkbox",
+        "id": "borders_enable",
+        "label": {
+          "en": "Show borders",
+          "de": "Grenzen anzeigen",
+          "es": "Mostrar bordes",
+          "fr": "Afficher les bordures",
+          "pt-PT": "Mostrar margens"
+        },
+        "default": false
+      },
+      {
+        "type": "select",
+        "id": "hover_effect",
+        "label": {
+          "en": "Product hover effect",
+          "de": "Hover-Effekt",
+          "es": "Efecto al pasar el cursor por encima",
+          "fr": "Effet de survol",
+          "pt-PT": "Efeito hover"
+        },
+        "default": "none",
+        "options": [
+          {
+            "value": "none",
+            "label": {
+              "en": "None",
+              "de": "Keiner",
+              "es": "Ninguno",
+              "fr": "Aucun",
+              "pt-PT": "Nenhum"
+            }
+          },
+          {
+            "value": "zoom",
+            "label": {
+              "en": "Zoom",
+              "de": "Zoom",
+              "es": "Zoom",
+              "fr": "Zoom",
+              "pt-PT": "Aumentar"
+            }
+          },
+          {
+            "value": "shadow",
+            "label": {
+              "en": "Shadow",
+              "de": "Schatten",
+              "es": "Sombreado",
+              "fr": "Ombre",
+              "pt-PT": "Sombra"
+            }
+          }
+        ]
+      },
+      {
+        "type": "select",
+        "id": "quick_add_position",
+        "label": {
+          "en": "Quick add position",
+          "de": "Position schnell hinzufügen",
+          "es": "Posición de adición rápida",
+          "fr": "Position d'ajout rapide",
+          "pt-PT": "Adicionar posição rapidamente"
+        },
+        "default": "none",
+        "options": [
+          {
+            "value": "none",
+            "label": {
+              "en": "None",
+              "de": "Keiner",
+              "es": "Ninguno",
+              "fr": "Aucun",
+              "pt-PT": "Nenhum"
+            }
+          },
+          {
+            "value": "above_product_details",
+            "label": {
+              "en": "Above product details",
+              "de": "Oberhalb der Produktdetails",
+              "es": "Detalles del producto de arriba",
+              "fr": "Au-dessus des informations du produit",
+              "pt-PT": "Acima dos detalhes do produto"
+            }
+          },
+          {
+            "value": "below_product_details",
+            "label": {
+              "en": "Below product details",
+              "de": "Unterhalb der Produktdetails",
+              "es": "Detalles del producto de debajo",
+              "fr": "Ci-dessous les informations du produit",
+              "pt-PT": "Abaixo dos detalhes do produto"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": {
+      "en": "Social media",
+      "de": "Social Media",
+      "es": "Redes sociales",
+      "fr": "Médias sociaux",
+      "pt-PT": "Redes sociais"
+    },
+    "settings": [
+      {
+        "type": "header",
+        "content": {
+          "en": "Accounts",
+          "fr": "Comptes",
+          "de": "Konten",
+          "es": "Cuentas",
+          "pt-PT": "Contas"
+        }
+      },
+      {
+        "type": "text",
+        "id": "sm_facebook_link",
+        "label": {
+          "en": "Facebook",
+          "de": "Facebook",
+          "es": "Facebook",
+          "fr": "Facebook",
+          "pt-PT": "Facebook"
+        },
+        "info": {
+          "en": "https://www.facebook.com/shopify",
+          "fr": "https://www.facebook.com/shopify",
+          "de": "https://www.facebook.com/shopify",
+          "es": "https://www.facebook.com/shopify",
+          "pt-PT": "https://www.facebook.com/shopify"
+        }
+      },
+      {
+        "type": "text",
+        "id": "sm_twitter_link",
+        "label": {
+          "en": "Twitter",
+          "de": "Twitter",
+          "es": "Twitter",
+          "fr": "Twitter",
+          "pt-PT": "Twitter"
+        },
+        "info": {
+          "en": "https://twitter.com/shopify",
+          "fr": "https://twitter.com/shopify",
+          "de": "https://twitter.com/shopify",
+          "es": "https://twitter.com/shopify",
+          "pt-PT": "https://twitter.com/shopify"
+        }
+      },
+      {
+        "type": "text",
+        "id": "sm_instagram_link",
+        "label": {
+          "en": "Instagram",
+          "de": "Instagram",
+          "es": "Instagram",
+          "fr": "Instagram",
+          "pt-PT": "Instagram"
+        },
+        "info": {
+          "en": "https://instagram.com/shopify",
+          "fr": "https://instagram.com/shopify",
+          "de": "https://instagram.com/shopify",
+          "es": "https://instagram.com/shopify",
+          "pt-PT": "https://instagram.com/shopify"
+        }
+      },
+      {
+        "type": "text",
+        "id": "sm_youtube_link",
+        "label": {
+          "en": "YouTube",
+          "fr": "YouTube",
+          "de": "YouTube",
+          "es": "YouTube",
+          "pt-PT": "YouTube"
+        },
+        "info": {
+          "en": "https://www.youtube.com/user/shopify",
+          "fr": "https://www.youtube.com/user/shopify",
+          "de": "https://www.youtube.com/user/shopify",
+          "es": "https://www.youtube.com/user/shopify",
+          "pt-PT": "https://www.youtube.com/user/shopify"
+        }
+      },
+      {
+        "type": "text",
+        "id": "sm_vimeo_link",
+        "label": {
+          "en": "Vimeo",
+          "fr": "Vimeo",
+          "de": "Vimeo",
+          "es": "Vimeo",
+          "pt-PT": "Vimeo"
+        },
+        "info": {
+          "en": "https://www.vimeo.com/shopify",
+          "fr": "https://www.vimeo.com/shopify",
+          "de": "https://www.vimeo.com/shopify",
+          "es": "https://www.vimeo.com/shopify",
+          "pt-PT": "https://www.vimeo.com/shopify"
+        }
+      },
+      {
+        "type": "text",
+        "id": "sm_tiktok_link",
+        "label": {
+          "en": "TikTok",
+          "fr": "TikTok",
+          "de": "TikTok",
+          "es": "TikTok",
+          "pt-PT": "TikTok"
+        },
+        "info": {
+          "en": "https://www.tiktok.com/@shopify",
+          "fr": "https://www.tiktok.com/@shopify",
+          "de": "https://www.tiktok.com/@shopify",
+          "es": "https://www.tiktok.com/@shopify",
+          "pt-PT": "https://www.tiktok.com/@shopify"
+        }
+      },
+      {
+        "type": "text",
+        "id": "sm_pinterest_link",
+        "label": {
+          "en": "Pinterest",
+          "de": "Pinterest",
+          "es": "Pinterest",
+          "fr": "Pinterest",
+          "pt-PT": "Pinterest"
+        },
+        "info": {
+          "en": "https://www.pinterest.com/shopify",
+          "fr": "https://www.pinterest.com/shopify",
+          "de": "https://www.pinterest.com/shopify",
+          "es": "https://www.pinterest.com/shopify",
+          "pt-PT": "https://www.pinterest.com/shopify"
+        }
+      },
+      {
+        "type": "text",
+        "id": "sm_snapchat_link",
+        "label": {
+          "en": "Snapchat",
+          "fr": "Snapchat",
+          "de": "Snapchat",
+          "es": "Snapchat",
+          "pt-PT": "Snapchat"
+        },
+        "info": {
+          "en": "https://snapchat.com/add/shopify",
+          "fr": "https://snapchat.com/add/shopify",
+          "de": "https://snapchat.com/add/shopify",
+          "es": "https://snapchat.com/add/shopify",
+          "pt-PT": "https://snapchat.com/add/shopify"
+        }
+      },
+      {
+        "type": "text",
+        "id": "sm_houzz_link",
+        "label": {
+          "en": "Houzz",
+          "fr": "Houzz",
+          "de": "Houzz",
+          "es": "Houzz",
+          "pt-PT": "Houzz"
+        },
+        "info": {
+          "en": "https://www.houzz.com/user",
+          "fr": "https://www.houzz.com/user",
+          "de": "https://www.houzz.com/user",
+          "es": "https://www.houzz.com/user",
+          "pt-PT": "https://www.houzz.com/user"
+        }
+      },
+      {
+        "type": "text",
+        "id": "sm_tumblr_link",
+        "label": {
+          "en": "Tumblr",
+          "fr": "Tumblr",
+          "de": "Tumblr",
+          "es": "Tumblr",
+          "pt-PT": "Tumblr"
+        },
+        "info": {
+          "en": "http://shopify.tumblr.com",
+          "fr": "http://shopify.tumblr.com",
+          "de": "http://shopify.tumblr.com",
+          "es": "http://shopify.tumblr.com",
+          "pt-PT": "http://shopify.tumblr.com"
+        }
+      },
+      {
+        "type": "text",
+        "id": "sm_linkedin_link",
+        "label": {
+          "en": "LinkedIn",
+          "fr": "LinkedIn",
+          "de": "LinkedIn",
+          "es": "LinkedIn",
+          "pt-PT": "LinkedIn"
+        },
+        "info": {
+          "en": "https://linkedin.com/company/shopify",
+          "fr": "https://linkedin.com/company/shopify",
+          "de": "https://linkedin.com/company/shopify",
+          "es": "https://linkedin.com/company/shopify",
+          "pt-PT": "https://linkedin.com/company/shopify"
+        }
+      }
+    ]
+  },
+  {
+    "name": {
+      "en": "Verification pop up",
+      "de": "Verifizierungs-Pop-up",
+      "es": "Ventana emergente de verificación",
+      "fr": "Fenêtre de vérification",
+      "pt-PT": "Pop-up de verificação"
+    },
+    "settings": [
+      {
+        "type": "checkbox",
+        "id": "enable_verification_popup",
+        "default": false,
+        "label": {
+          "en": "Enable verification pop up",
+          "de": "Verifizierungs-Pop-up aktivieren",
+          "es": "Activar ventana emergente de verificación",
+          "fr": "Activer la fenêtre de vérification",
+          "pt-PT": "Ativar pop-up de verificação"
+        }
+      },
+      {
+        "type": "checkbox",
+        "id": "verification-pop-up__test-mode",
+        "label": {
+          "en": "Enable test mode",
+          "fr": "Activer le mode test",
+          "de": "Aktiviere Testmodus",
+          "es": "Activar modo de prueba",
+          "pt-PT": "Ativar modo de teste"
+        },
+        "info": {
+          "en": "Forces the verification to show on every refresh, and should only be used for editing the popup. Ensure 'Test mode' is disabled when launching your store.",
+          "de": "Erzwingt das Erscheinen des Verifizierungs-Pop-ups bei jeder Aktualisierung und sollte nur zum Bearbeiten des Pop-ups verwendet werden. Stellen Sie sicher, dass 'Testmodus' deaktiviert ist, wenn Sie Ihren Shop in Betrieb.",
+          "es": "Hace que la verificación se muestre cada vez que se recargue la página. Solo debe usarse para editar la ventana emergente. Asegúrate de que el \"Modo de prueba\" esté desactivado al abrir tu tienda.",
+          "fr": "Force la vérification à s'afficher à chaque actualisation, ne doit être utilisé que pour modifier la fenêtre contextuelle. Assurez-vous que le « mode test » est désactivé lors du lancement de votre boutique.",
+          "pt-PT": "Força a mostrar a verificação em cada atualização e deve ser utilizado apenas para editar o pop-up. Confirme que o 'Modo de Teste' está desativado quando abrir a sua loja."
+        }
+      },
+      {
+        "type": "header",
+        "content": {
+          "en": "Background color",
+          "de": "Hintergrundfarbe",
+          "es": "Color de fondo",
+          "fr": "Couleur de l'arrière plan",
+          "pt-PT": "Cor de fundo"
+        }
+      },
+      {
+        "type": "color",
+        "id": "verification-popup--background-color",
+        "label": {
+          "en": "Background",
+          "de": "Hintergrund",
+          "es": "Fondo",
+          "fr": "Contexte général",
+          "pt-PT": "Fundo"
+        },
+        "default": "#333333"
+      },
+      {
+        "type": "header",
+        "content": {
+          "en": "Background image",
+          "de": "Hintergrundbild",
+          "es": "Imagen de fondo",
+          "fr": "Image d'arrière-plan",
+          "pt-PT": "Imagem de fundo"
+        }
+      },
+      {
+        "type": "image_picker",
+        "id": "verification-popup--background-image",
+        "label": {
+          "en": "Image",
+          "de": "Bild",
+          "es": "Imagen",
+          "fr": "Image",
+          "pt-PT": "Imagem"
+        },
+        "info": {
+          "en": "2000 x 800px recommended",
+          "de": "2000 x 800 px empfohlen",
+          "es": "Recomendado 2000 x 800 px",
+          "fr": "2000 x 800 px recommandé",
+          "pt-PT": "2000 x 800px, recomendado"
+        }
+      },
+      {
+        "type": "header",
+        "content": {
+          "en": "Logo",
+          "de": "Logo",
+          "es": "Logotipo",
+          "fr": "Logo",
+          "pt-PT": "Logótipo"
+        }
+      },
+      {
+        "type": "image_picker",
+        "id": "verification-popup__logo",
+        "label": {
+          "en": "Logo image",
+          "de": "Logobild",
+          "es": "Imagen del logotipo",
+          "fr": "Image du logo",
+          "pt-PT": "Imagem do logótipo"
+        },
+        "info": {
+          "en": "250 x 133px recommended",
+          "de": "250 x 133 px empfohlen",
+          "es": "Recomendado 250 x 133 px",
+          "fr": "250 x 133 px recommandé",
+          "pt-PT": "250 x 133px, recomendado"
+        }
+      },
+      {
+        "type": "range",
+        "id": "verification-popup-logo--max-width",
+        "min": 50,
+        "max": 500,
+        "step": 10,
+        "unit": {
+          "en": "px",
+          "de": "px",
+          "es": "px",
+          "fr": "px",
+          "pt-PT": "px"
+        },
+        "label": {
+          "en": "Preferred width",
+          "de": "Bevorzugte Breite",
+          "es": "Ancho preferido",
+          "fr": "Largeur préférée",
+          "pt-PT": "Largura preferida"
+        },
+        "default": 50
+      },
+      {
+        "type": "header",
+        "content": {
+          "en": "Verification question",
+          "de": "Verifizierungsfrage",
+          "es": "Pregunta de verificación",
+          "fr": "Question de vérification",
+          "pt-PT": "Questão de verificação"
+        }
+      },
+      {
+        "type": "text",
+        "id": "verification-pop-up__header",
+        "label": {
+          "en": "Heading",
+          "de": "Überschrift",
+          "es": "Encabezado",
+          "fr": "Rubrique",
+          "pt-PT": "Título"
+        },
+        "default": {
+          "en": "Confirm your age",
+          "de": "Bestätigen Sie Ihr Alter",
+          "es": "Confirma tu edad",
+          "fr": "Confirmez votre âge",
+          "pt-PT": "Confirme a sua idade"
+        }
+      },
+      {
+        "type": "richtext",
+        "id": "verification-pop-up__description",
+        "label": {
+          "en": "Verification question",
+          "de": "Verifizierungsfrage",
+          "es": "Pregunta de verificación",
+          "fr": "Question de vérification",
+          "pt-PT": "Questão de verificação"
+        },
+        "default": {
+          "en": "<p>You must be at least 21 years old to enter this store.</p><p>Are you over 21 years of age?</p>",
+          "de": "<p>Sie müssen mindestens 21 Jahre alt sein, um diesen Shop zu betreten.</p><p>Sind Sie über 21 Jahre alt?</p>",
+          "es": "<p>Debes ser mayor de 21 años para entrar a esta tienda.</p><p>¿Tienes más de 21 años?</p>",
+          "fr": "<p>Vous devez avoir au moins 21 ans pour entrer dans ce magasin.</p><p>Avez-vous plus de 21 ans?</p>",
+          "pt-PT": "<p>Deve ter pelo menos 21 anos para entrar nesta loja.</p><p>Tem mais de 21 anos?</p>"
+        }
+      },
+      {
+        "type": "text",
+        "id": "exit-button__text",
+        "label": {
+          "en": "Decline button text",
+          "de": "Ablehnungs-Buttontext",
+          "es": "Texto del botón de rechazo",
+          "fr": "Texte du bouton de refus",
+          "pt-PT": "Texto do botão de recusar"
+        },
+        "default": {
+          "en": "No I'm not",
+          "de": "<p>Nein, bin ich nicht</p>",
+          "es": "<p>No</p>",
+          "fr": "<p>Non</p>",
+          "pt-PT": "<p>Não, não tenho</p>"
+        }
+      },
+      {
+        "type": "text",
+        "id": "confirm-button__text",
+        "label": {
+          "en": "Approve button text",
+          "de": "Bestätigungs-Buttontext",
+          "es": "Texto del botón de aprobación",
+          "fr": "Texte du bouton de validation",
+          "pt-PT": "Texto do botão de aprovar"
+        },
+        "default": {
+          "en": "Yes I am",
+          "de": "<p>Ja, bin ich</p>",
+          "es": "<p>Sí</p>",
+          "fr": "<p>Oui</p>",
+          "pt-PT": "<p>Sim, tenho</p>"
+        }
+      },
+      {
+        "type": "header",
+        "content": {
+          "en": "Declined",
+          "de": "Abgelehnt",
+          "es": "Acceso denegado",
+          "fr": "Refusé",
+          "pt-PT": "Recusado"
+        },
+        "info": {
+          "en": "This content will display if the user does not meet the verification requirements.",
+          "de": "Dieser Inhalt wird angezeigt, wenn der Nutzer die Verifizierungsbedingungen nicht erfüllt.",
+          "es": "Este mensaje se mostrará si el usuario no cumple con los requisitos de verificación.",
+          "fr": "Ce contenu s'affichera si l'utilisateur ne répond pas aux exigences de vérification.",
+          "pt-PT": "Este conteúdo será exibido se o utilizador não cumprir os requisitos de verificação."
+        }
+      },
+      {
+        "type": "text",
+        "id": "deny__header",
+        "label": {
+          "en": "Heading",
+          "de": "Überschrift",
+          "es": "Encabezado",
+          "fr": "Rubrique",
+          "pt-PT": "Título"
+        },
+        "default": {
+          "en": "Come back when you're older",
+          "de": "Kommen Sie wieder, wenn Sie älter sind",
+          "es": "Vuelve cuando seas mayor",
+          "fr": "Reviens quand tu seras plus vieux",
+          "pt-PT": "Volte quando for mais velho"
+        }
+      },
+      {
+        "type": "richtext",
+        "id": "deny__description",
+        "label": {
+          "en": "Text",
+          "de": "Text",
+          "es": "Texto",
+          "fr": "Texte",
+          "pt-PT": "Texto"
+        },
+        "default": {
+          "en": "<p>It looks like you're not old enough to shop with us, come back when you're 21 or older.</p>",
+          "de": "<p>Es scheint, dass Sie nicht alt genug sind, um bei uns einzukaufen. Kommen Sie wieder, wenn Sie 21 oder älter sind.</p>",
+          "es": "<p>Parece que no tienes la edad suficiente para comprar en nuestra tienda, vuelve cuando tengas 21 años o más.</p>",
+          "fr": "<p>On dirait que vous n'êtes pas assez vieux pour faire du shopping avec nous, revenez quand vous aurez 21 ans ou plus.</p>",
+          "pt-PT": "<p>Parece que não tem idade suficiente para comprar connosco, volte quando tiver 21 anos ou mais.</p>"
+        }
+      },
+      {
+        "type": "text",
+        "id": "deny-button__text",
+        "label": {
+          "en": "Return button text",
+          "de": "Rückkehr-Buttontext",
+          "es": "Texto del botón de retorno",
+          "fr": "Texte du bouton de retour",
+          "pt-PT": "Texto do botão de voltar"
+        },
+        "default": {
+          "en": "Oops, I entered incorrectly",
+          "de": "<p>Hoppla, meine Eingabe war falsch</p>",
+          "es": "<p>Uy, me he equivocado</p>",
+          "fr": "<p>Oups, je me suis trompé</p>",
+          "pt-PT": "<p>Ups, introduzi incorretamente</p>"
+        }
+      }
+    ]
+  },
+  {
+    "name": {
+      "en": "Popup",
+      "fr": "Pop-up",
+      "de": "Popup",
+      "es": "Emergente",
+      "pt-PT": "Popup"
+    },
+    "settings": [
+      {
+        "type": "checkbox",
+        "id": "popup--enable",
+        "label": {
+          "en": "Enable popup",
+          "de": "Aktivieren",
+          "es": "Habilitar",
+          "fr": "Activer",
+          "pt-PT": "Ativar"
+        }
+      },
+      {
+        "type": "checkbox",
+        "id": "popup--test-mode",
+        "label": {
+          "en": "Enable test mode",
+          "fr": "Activer le mode test",
+          "de": "Aktiviere Testmodus",
+          "es": "Activar modo de prueba",
+          "pt-PT": "Ativar modo de teste"
+        },
+        "info": {
+          "en": "Forces the popup to show on every page, and should only be used for editing the popup. Ensure 'Test mode' is disabled when launching your store.",
+          "fr": "Le mode test impose l’affichage du pop-up sur chaque page et ne doit être utilisé qu’en phase d’édition. Assurez-vous d’avoir désactivé le mode test avant d’ouvrir votre boutique ",
+          "de": "Testmodus zwingt das Popup auf jeder Seite angezeigt zu werden und sollte nur benutzt werden, um das Popup zu bearbeiten. Stellen Sie sicher, dass 'Testmodus' deaktiviert ist, wenn Sie Ihren Store starten",
+          "es": "El modo de prueba fuerza la aparición del emergente en todas las páginas, y solo se puede usar para editar el emergente. Asegúrese de que el «Modo de prueba» está desactivado al lanzar la tienda.",
+          "pt-PT": "O modo de teste obriga o popup a exibir em todas as páginas e só deve ser utilizado para editar o popup. Certifique-se que o 'Modo de teste' está desativado quando lançar a sua loja."
+        }
+      },
+      {
+        "type": "text",
+        "id": "pop-up-text-header-text",
+        "label": {
+          "en": "Heading",
+          "de": "Überschrift",
+          "es": "Encabezado",
+          "fr": "Rubrique",
+          "pt-PT": "Título"
+        },
+        "default": {
+          "en": "Popup",
+          "fr": "Pop-up",
+          "de": "Popup",
+          "es": "Emergente",
+          "pt-PT": "Popup"
+        }
+      },
+      {
+        "type": "richtext",
+        "id": "pop-up-text-description-text",
+        "label": {
+          "en": "Text",
+          "de": "Text",
+          "es": "Texto",
+          "fr": "Texte",
+          "pt-PT": "Texto"
+        },
+        "default": {
+          "en": "<p>Use this popup to embed a mailing list signup form. Offer incentives to customers to join and build your mailing list.</p>",
+          "de": "<p>Verwenden Sie dieses Pop-up, um ein Anmeldeformular für den E-Mail-Verteiler einzupflegen. Bieten Sie Kunden Anreize, um sich in Ihren E-Mail-Verteiler einzutragen und diesen aufzubauen.</p>",
+          "es": "<p>Utilizar esta ventana emergente para insertar un formulario de registro de la lista de correo. Ofrecer incentivos a los clientes para que se unan y se pueda crear la lista de correo.</p>",
+          "fr": "<p>Utilisez cette fenêtre contextuelle pour intégrer un formulaire d’inscription à une liste de diffusion. Encouragez vos clients à s'inscrire dans votre liste de diffusion et à y contribuer.</p>",
+          "pt-PT": "<p>Use esta janela para incorporar um formulário de subscrição numa lista de correio. Ofereça incentivos aos clientes para aderirem e construa a sua lista de subscritores.</p>"
+        }
+      },
+      {
+        "type": "image_picker",
+        "id": "popup-newsletter-image",
+        "label": {
+          "en": "Image",
+          "de": "Bild",
+          "es": "Imagen",
+          "fr": "Image",
+          "pt-PT": "Imagem"
+        },
+        "info": {
+          "en": "400 x 400px recommended",
+          "fr": "400 x 400 px recommandé",
+          "de": "400 x 400 px empfohlen",
+          "es": "Se recomienda 400 x 400 px",
+          "pt-PT": "400 x 400px recomendado"
+        }
+      },
+      {
+        "type": "select",
+        "id": "pop-up-time",
+        "label": {
+          "en": "Days until popup is displayed again",
+          "fr": "Jours avant que le pop-up soit de nouveau affiché",
+          "de": "Tage bis dieses Popup wieder angezeigt wird",
+          "es": "Días que faltan para que el emergente aparezca nuevamente",
+          "pt-PT": "Dias até nova exibição da mensagem popup"
+        },
+        "options": [
+          {
+            "value": "7",
+            "label": {
+              "en": "One week",
+              "fr": "Une semaine",
+              "de": "Eine Woche",
+              "es": "Una semana",
+              "pt-PT": "Uma semana"
+            }
+          },
+          {
+            "value": "14",
+            "label": {
+              "en": "Two weeks",
+              "fr": "Deux semaines",
+              "de": "Zwei Wochen",
+              "es": "Dos semanas",
+              "pt-PT": "Duas semanas"
+            }
+          },
+          {
+            "value": "21",
+            "label": {
+              "en": "Three weeks",
+              "fr": "Trois semaines",
+              "de": "Drei Wochen",
+              "es": "Tres semanas",
+              "pt-PT": "Três semanas"
+            }
+          },
+          {
+            "value": "28",
+            "label": {
+              "en": "Four weeks",
+              "fr": "Quatre semaines",
+              "de": "Vier Wochen",
+              "es": "Cuatro semanas",
+              "pt-PT": "Quatro semanas"
+            }
+          }
+        ],
+        "default": "7"
+      },
+      {
+        "type": "range",
+        "id": "popup-delay",
+        "min": 1,
+        "max": 15,
+        "step": 1,
+        "unit": {
+          "en": "sec",
+          "de": "Sek.",
+          "es": "seg",
+          "fr": "sec.",
+          "pt-PT": "seg"
+        },
+        "label": {
+          "en": "Delay until popup appears",
+          "fr": "Attendre jusqu’à l’apparition du pop-up",
+          "de": "Verzögerung bis Popup erscheint",
+          "es": "Demorar hasta que aparezca el emergente",
+          "pt-PT": "Adiar até a mensagem popup aparecer"
+        },
+        "default": 5
+      },
+      {
+        "type": "checkbox",
+        "id": "popup--show-social-icons",
+        "label": {
+          "en": "Enable social icons",
+          "fr": "Activer les icônes de réseaux sociaux",
+          "de": "Aktiviere Buttons für Social Media",
+          "es": "Activar iconos de medios sociales",
+          "pt-PT": "Ativar ícones sociais"
+        }
+      },
+      {
+        "type": "checkbox",
+        "id": "popup--show-newsletter",
+        "label": {
+          "en": "Enable newsletter signup",
+          "fr": "Activer l’inscription à une newsletter",
+          "de": "Aktiviere Newsletter-Anmeldung",
+          "es": "Activar la subscripción al boletín de noticias",
+          "pt-PT": "Ativar subscrição da newsletter"
+        },
+        "default": true
+      }
+    ]
+  },
+  {
+    "name": {
+      "en": "Favicon",
+      "fr": "Favicon",
+      "de": "Favicon",
+      "es": "Favicón",
+      "pt-PT": "Favicon"
+    },
+    "settings": [
+      {
+        "type": "image_picker",
+        "id": "favicon",
+        "label": {
+          "en": "Favicon image",
+          "fr": "Image de favicon",
+          "de": "Favicon-Bild",
+          "es": "Imagen del favicón",
+          "pt-PT": "Imagem do favicon"
+        },
+        "info": {
+          "en": "Will be scaled down to 32 x 32px",
+          "fr": "Sera réduit en 32 x 32 px",
+          "de": "Wird herunterskaliert auf 32 x 32 px.",
+          "es": "Se reducirá a 32 x 32 px",
+          "pt-PT": "Será reduzido para 32 x 32px"
+        }
+      }
+    ]
+  },
+  {
+    "name": {
+      "en": "Search",
+      "fr": "Recherche",
+      "de": "Suche",
+      "es": "Búsqueda",
+      "pt-PT": "Pesquisar"
+    },
+    "settings": [
+      {
+        "type": "checkbox",
+        "id": "predictive_search_enabled",
+        "label": {
+          "en": "Enable predictive search",
+          "de": "Prädiktive Suche aktivieren",
+          "es": "Habilitar búsqueda predictiva",
+          "fr": "Activer la recherche prédictive",
+          "pt-PT": "Ativar pesquisa preditiva"
+        },
+        "default": true
+      },
+      {
+        "type": "header",
+        "content": {
+          "en": "Search includes",
+          "de": "Die Suche beinhaltet",
+          "es": "La búsqueda incluye",
+          "fr": "La recherche inclus",
+          "pt-PT": "A pesquisa inclui"
+        }
+      },
+      {
+        "type": "checkbox",
+        "id": "enable-product-results",
+        "label": {
+          "en": "Products",
+          "de": "Produkte",
+          "es": "Productos",
+          "fr": "Produits",
+          "pt-PT": "Produtos"
+        },
+        "default": true
+      },
+      {
+        "type": "checkbox",
+        "id": "enable-page-results",
+        "label": {
+          "en": "Pages",
+          "de": "Seiten",
+          "es": "Páginas",
+          "fr": "Pages",
+          "pt-PT": "Páginas"
+        },
+        "default": false
+      },
+      {
+        "type": "checkbox",
+        "id": "enable-article-results",
+        "label": {
+          "en": "Articles",
+          "de": "Artikel",
+          "es": "Artículos",
+          "fr": "Des articles",
+          "pt-PT": "Artigos"
+        },
+        "default": false
+      },
+      {
+        "type": "checkbox",
+        "id": "enable-collection-results",
+        "label": {
+          "en": "Collections",
+          "de": "Sammlungen",
+          "es": "Colecciones",
+          "fr": "Les collections",
+          "pt-PT": "Coleções"
+        },
+        "default": false,
+        "info": {
+          "en": "Only available in predictive search",
+          "de": "Nur bei der prädiktiven Suche verfügbar",
+          "es": "Disponible solo en la búsqueda predictiva.",
+          "fr": "Disponible uniquement en recherche prédictive",
+          "pt-PT": "Disponível apenas na pesquisa preditiva"
+        }
+      },
+      {
+        "type": "header",
+        "content": {
+          "en": "Products",
+          "de": "Produkte",
+          "es": "Productos",
+          "fr": "Des produits",
+          "pt-PT": "Produtos"
+        }
+      },
+      {
+        "type": "checkbox",
+        "id": "predictive_search_show_vendor",
+        "label": {
+          "en": "Show vendor",
+          "de": "Verkäufer anzeigen",
+          "es": "Mostrar vendedor",
+          "fr": "Afficher le vendeur",
+          "pt-PT": "Mostrar vendedor"
+        },
+        "default": false,
+        "info": {
+          "en": "Only available in predictive search",
+          "de": "Nur bei der prädiktiven Suche verfügbar",
+          "es": "Disponible solo en la búsqueda predictiva.",
+          "fr": "Disponible uniquement en recherche prédictive",
+          "pt-PT": "Disponível apenas na pesquisa preditiva"
+        }
+      },
+      {
+        "type": "checkbox",
+        "id": "predictive_search_show_price",
+        "label": {
+          "en": "Show price",
+          "de": "Preis anzeigen",
+          "es": "Mostrar precio",
+          "fr": "Afficher le prix",
+          "pt-PT": "Mostrar preço"
+        },
+        "default": false,
+        "info": {
+          "en": "Only available in predictive search",
+          "de": "Nur bei der prädiktiven Suche verfügbar",
+          "es": "Disponible solo en la búsqueda predictiva.",
+          "fr": "Disponible uniquement en recherche prédictive",
+          "pt-PT": "Disponível apenas na pesquisa preditiva"
+        }
+      }
+    ]
+  },
+  {
+    "name": "Free delivery promotion",
+    "settings": [
+      {
+        "type": "checkbox",
+        "id": "enable_free_delivery_promo",
+        "label": "Enable free delivery promotion",
+        "default": false
+      },
+      {
+        "type": "number",
+        "id": "free_delivery_threshold",
+        "label": "Free delivery threshold",
+        "default": 21
+      },
+      {
+        "type": "text",
+        "id": "free_delivery_locked_message",
+        "label": "Locked message",
+        "default": "Add {remaining} more meals to unlock free delivery."
+      },
+      {
+        "type": "text",
+        "id": "free_delivery_unlocked_message",
+        "label": "Unlocked message",
+        "default": "You've unlocked free delivery."
+      },
+      {
+        "type": "text",
+        "id": "free_delivery_discount_code",
+        "label": "Discount code (optional)"
+      },
+      {
+        "type": "text",
+        "id": "announcement_default_text",
+        "label": "Announcement bar text when promo off",
+        "default": "USDA Certified • Serving the lower 48"
+      },
+      {
+        "type": "text",
+        "id": "announcement_promo_text",
+        "label": "Announcement bar text when promo on",
+        "default": "Stock up on ICON Meals!"
+      }
+    ]
+  },
+  {
+    "name": "Meal Plan Promo",
+    "settings": [
+      {
+        "type": "checkbox",
+        "id": "meal_plan_promo_enable",
+        "label": "Enable Meal Plan promo",
+        "default": false
+      },
+      {
+        "type": "checkbox",
+        "id": "meal_plan_promo_list_enable",
+        "label": "Enable on Meal Plan list page",
+        "default": true
+      },
+      {
+        "type": "checkbox",
+        "id": "meal_plan_promo_pdp_enable",
+        "label": "Enable on Meal Plan product pages",
+        "default": true
+      },
+      {
+        "type": "checkbox",
+        "id": "meal_plan_promo_cart_enable",
+        "label": "Enable on cart surfaces",
+        "default": true
+      },
+      {
+        "type": "text",
+        "id": "meal_plan_promo_name",
+        "label": "Sale name",
+        "default": "Labor Day"
+      },
+      {
+        "type": "text",
+        "id": "meal_plan_promo_end_date",
+        "label": "End date (YYYY-MM-DD)",
+        "default": "2024-09-02"
+      },
+      {
+        "type": "text",
+        "id": "meal_plan_promo_savings_12",
+        "label": "Box 1 savings for 12-meal plan",
+        "default": ""
+      },
+      {
+        "type": "text",
+        "id": "meal_plan_promo_savings_24",
+        "label": "Box 1 savings for 24-meal plan",
+        "default": ""
+      }
+    ]
+  }
 ]

--- a/sections/custom-meal-plan-grid.liquid
+++ b/sections/custom-meal-plan-grid.liquid
@@ -127,6 +127,7 @@
             </div>
 
             <div class="meal-plan-card__content">
+          {% render 'meal-plan-promo-breadcrumb', context: 'plan-card' %}
               <div class="meal-plan-card__main-info">
                 {%- if has_benefits -%}
                   <div class="meal-plan-card__benefits-block">

--- a/sections/custom-meal-plan-header.liquid
+++ b/sections/custom-meal-plan-header.liquid
@@ -97,6 +97,7 @@
           {%- if section.settings.intro_text != blank -%}
             <div class="meal-plan-header__intro rte">{{ section.settings.intro_text }}</div>
           {%- endif -%}
+          {% render 'meal-plan-promo-breadcrumb', context: 'list-line' %}
         </div>
         <div class="meal-plan-header__features">
           <ul class="header-feature-list">

--- a/sections/product-main-meal-plan.liquid
+++ b/sections/product-main-meal-plan.liquid
@@ -72,6 +72,7 @@
             <div class="meal-plan-form__price" data-product-price>
               {{ current_variant.price | money }}
             </div>
+            {% render 'meal-plan-promo-breadcrumb', context: 'pdp' %}
 
             <div class="meal-plan-form__actions">
               <product-form class="product-form--quick-add product-form--full-width" data-state="{% if qty_in_cart > 0 %}active{% else %}initial{% endif %}">

--- a/snippets/cart-item-list.liquid
+++ b/snippets/cart-item-list.liquid
@@ -79,6 +79,7 @@ endif
             <a href="{{ item.url }}" class="{{ class_prefix }}__item-title" title="{{ item.product.title }}">{{ item.product.title }}</a>
             <div class="{{ class_prefix }}__item-meta">
               <span class="{{ class_prefix }}__item-price">{{ line_item_price | money }}</span>
+            {% render 'meal-plan-promo-breadcrumb', context: 'cart-item', item: item %}
               <div class="{{ class_prefix }}__item-actions">
                 <div class="{{ class_prefix }}__quantity-selector{% if is_bogo_gift %} {{ class_prefix }}__quantity-selector--static{% endif %}">
                   {% unless is_bogo_gift %}

--- a/snippets/meal-plan-promo-breadcrumb.liquid
+++ b/snippets/meal-plan-promo-breadcrumb.liquid
@@ -1,0 +1,67 @@
+{% comment %}
+  Renders meal plan promotion breadcrumb elements based on context.
+  Usage: {% render 'meal-plan-promo-breadcrumb', context: 'list-line' %}
+{% endcomment %}
+
+{% assign promo_end = settings.meal_plan_promo_end_date | default: '' %}
+{% assign promo_end_timestamp = promo_end | date: '%s' %}
+{% assign now_timestamp = 'now' | date: '%s' %}
+{% assign promo_active = false %}
+{% if settings.meal_plan_promo_enable %}
+  {% if promo_end == blank or promo_end_timestamp >= now_timestamp %}
+    {% assign promo_active = true %}
+  {% endif %}
+{% endif %}
+
+{% if promo_active %}
+  {% case context %}
+    {% when 'list-line' %}
+      {% if settings.meal_plan_promo_list_enable %}
+        <div class="mp-promo-line">
+          <span>{{ settings.meal_plan_promo_name }} is live. Save up to $180 with Subscribe & Save. Ends {{ settings.meal_plan_promo_end_date | date: '%b %-d' }}.</span>
+          <details class="mp-promo-how"><summary>How it works</summary><div>Extra savings apply to your first 4 boxes when you choose Subscribe & Save. Amount varies by plan size.</div></details>
+        </div>
+      {% endif %}
+    {% when 'plan-card' %}
+      {% if settings.meal_plan_promo_list_enable %}
+        <div class="mp-plan-card-badge">
+          <span class="mp-badge">Save up to $180</span>
+          <small class="mp-sub">Applied to first 4 boxes with Subscribe & Save.</small>
+        </div>
+      {% endif %}
+    {% when 'pdp' %}
+      {% if settings.meal_plan_promo_pdp_enable %}
+        <div class="mp-pdp-callout">
+          <span class="mp-pill">Labor Day bonus in cart</span>
+          <small class="mp-sub">Extra savings apply in cart, on top of Subscribe & Save.</small>
+        </div>
+      {% endif %}
+    {% when 'cart-item' %}
+      {% if settings.meal_plan_promo_cart_enable and item %}
+        {% assign is_meal_plan = false %}
+        {% assign product_type_lower = item.product.type | downcase %}
+        {% if product_type_lower contains 'meal plan' or item.product.handle contains 'meal-plan' %}
+          {% assign is_meal_plan = true %}
+        {% endif %}
+        {% if is_meal_plan and item.selling_plan_allocation %}
+          <div class="mp-cart-note">
+            <span>Labor Day savings applied.</span>
+            <small>Box 1 savings shown. Boxes 2–4 auto-apply with Subscribe & Save.</small>
+          </div>
+        {% endif %}
+      {% endif %}
+  {% endcase %}
+{% endif %}
+
+<style>
+  .mp-promo-line{font-size:0.875rem;margin-top:0.5rem;text-align:center}
+  .mp-promo-line details{display:inline-block;margin-left:0.5rem}
+  .mp-plan-card-badge{text-align:center;margin-bottom:0.5rem}
+  .mp-plan-card-badge .mp-badge{display:inline-block;background:#d42828;color:#fff;font-size:0.75rem;padding:0.1rem 0.5rem;border-radius:4px}
+  .mp-plan-card-badge .mp-sub{display:block;font-size:0.75rem;color:#495057;margin-top:0.25rem}
+  .mp-pdp-callout{margin-top:0.5rem}
+  .mp-pdp-callout .mp-pill{display:inline-block;background:#f8d7da;color:#721c24;font-size:0.75rem;padding:0.2rem 0.6rem;border-radius:999px}
+  .mp-pdp-callout .mp-sub{display:block;font-size:0.75rem;color:#495057;margin-top:0.25rem}
+  .mp-cart-note{font-size:0.75rem;color:#495057;margin-top:0.25rem}
+  .mp-cart-note span{color:#d42828;display:block}
+</style>


### PR DESCRIPTION
## Summary
- add global meal plan promo settings for sale name, end date, and per-surface toggles
- show reusable promo breadcrumb on meal plan list, product, and cart surfaces

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af20ea2e98832fb96e21f72e028518