### PR TITLE
Update Labor Day promo end date

### DIFF
--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -2326,7 +2326,7 @@
         "type": "text",
         "id": "meal_plan_promo_end_date",
         "label": "End date (YYYY-MM-DD)",
-        "default": "2024-09-02"
+        "default": "2025-09-02"
       },
       {
         "type": "text",


### PR DESCRIPTION
## Summary
- keep Meal Plan promo active by default for Labor Day 2025

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af33686f1c832f85ad9d2ebcc9b4dd