### PR TITLE
Add Recharge-powered custom meal template

### DIFF
--- a/assets/cm-recharge.css
+++ b/assets/cm-recharge.css
@@ -1,0 +1,21 @@
+.cm-recharge__form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.cm-recharge__quantity {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.cm-recharge__total {
+  margin-top: 1rem;
+  font-weight: 600;
+}
+
+.cm-recharge__error {
+  color: #c01923;
+  margin-top: 0.5rem;
+}

--- a/assets/cm-recharge.js
+++ b/assets/cm-recharge.js
@@ -1,0 +1,171 @@
+import Recharge from 'https://cdn.rechargeapps.com/storefront-sdk/latest/recharge-storefront.min.js';
+
+// Basic bundle builder for Custom Meal using Recharge Storefront API
+// Handles option selection, price calculation, validation and add to cart
+
+async function initBundleBuilder() {
+  const root = document.querySelector('.cm-recharge');
+  if (!root || !Recharge) return;
+
+  const client = new Recharge.StorefrontClient(window.rechargeStorefrontApiKey || '', {
+    myshopify_domain: window.Shopify && Shopify.shop
+  });
+
+  const proteinHandle = root.dataset.proteinHandle;
+  const sideHandle = root.dataset.sideHandle;
+  const proteinSelect = root.querySelector('[data-protein-select]');
+  const side1Select = root.querySelector('[data-side1-select]');
+  const side2Select = root.querySelector('[data-side2-select]');
+  const seasoningField = root.querySelector('[data-seasoning-field]');
+  const freqContainer = root.querySelector('[data-frequency-options]');
+  const qtyInput = root.querySelector('[data-qty-input]');
+  const totalDisplay = root.querySelector('[data-total-price]');
+  const addBtn = root.querySelector('[data-add]');
+  const errorBox = root.querySelector('[data-error]');
+
+  const productData = JSON.parse(root.nextElementSibling?.textContent || '{}');
+  const sellingPlans = JSON.parse(root.nextElementSibling?.nextElementSibling?.textContent || '[]');
+
+  const state = {
+    protein: null,
+    side1: null,
+    side2: null,
+    qty: 1,
+    frequency: null,
+    prices: {}
+  };
+
+  function money(cents) {
+    return Shopify.formatMoney(cents, Shopify.money_format || '${{amount}}');
+  }
+
+  function updateTotal() {
+    const ids = [state.protein, state.side1, state.side2].filter(Boolean);
+    const sum = ids.reduce((acc, id) => acc + (state.prices[id] || 0), 0) * state.qty;
+    totalDisplay.textContent = ids.length ? money(sum) : '';
+  }
+
+  function validate() {
+    const valid = state.protein && state.side1 && state.side2;
+    addBtn.disabled = !valid;
+    errorBox.textContent = valid ? '' : 'Please choose 1 protein and 2 sides';
+    return valid;
+  }
+
+  function update() {
+    updateTotal();
+    validate();
+  }
+
+  // Quantity controls
+  root.querySelector('[data-qty-plus]').addEventListener('click', () => {
+    state.qty++;
+    qtyInput.value = state.qty;
+    update();
+  });
+  root.querySelector('[data-qty-minus]').addEventListener('click', () => {
+    if (state.qty > 1) {
+      state.qty--;
+      qtyInput.value = state.qty;
+      update();
+    }
+  });
+
+  // load collection products
+  async function loadCollection(handle) {
+    const res = await client.collectionByHandle(handle, { productsFirst: 50 });
+    return res?.collection?.products?.edges?.map(e => e.node) || [];
+  }
+
+  function populate(select, products) {
+    select.innerHTML = '<option value="">Select</option>';
+    products.forEach(p => {
+      p.variants.edges.forEach(({ node }) => {
+        const opt = document.createElement('option');
+        opt.value = node.id;
+        opt.textContent = `${p.title} - ${node.title}`;
+        state.prices[node.id] = parseInt(node.price.amount * 100);
+        select.appendChild(opt);
+      });
+    });
+  }
+
+  const [proteins, sides] = await Promise.all([
+    loadCollection(proteinHandle),
+    loadCollection(sideHandle)
+  ]);
+  populate(proteinSelect, proteins);
+  populate(side1Select, sides);
+  populate(side2Select, sides);
+
+  // show seasoning field if param exists
+  const params = new URLSearchParams(location.search);
+  if (params.get('seasoning') !== null) {
+    seasoningField.hidden = false;
+    root.querySelector('[data-seasoning-input]').value = params.get('seasoning');
+  }
+
+  // frequency options
+  const oneTime = document.createElement('label');
+  oneTime.innerHTML = `<input type="radio" name="freq" value=""> One-time purchase`;
+  freqContainer.appendChild(oneTime);
+  sellingPlans.forEach(group => {
+    group.selling_plans.forEach(plan => {
+      const lbl = document.createElement('label');
+      lbl.innerHTML = `<input type="radio" name="freq" value="${plan.id}"> ${plan.options[0].value}`;
+      freqContainer.appendChild(lbl);
+    });
+  });
+  freqContainer.addEventListener('change', e => {
+    state.frequency = e.target.value || null;
+  });
+
+  function prefill(select, value) {
+    if (!value) return;
+    const opt = select.querySelector(`option[value="${value}"]`);
+    if (opt) {
+      select.value = value;
+      select.dispatchEvent(new Event('change'));
+    }
+  }
+
+  proteinSelect.addEventListener('change', e => { state.protein = e.target.value || null; update(); });
+  side1Select.addEventListener('change', e => { state.side1 = e.target.value || null; update(); });
+  side2Select.addEventListener('change', e => { state.side2 = e.target.value || null; update(); });
+
+  // URL prefill
+  prefill(proteinSelect, params.get('protein'));
+  prefill(side1Select, params.get('side1'));
+  prefill(side2Select, params.get('side2'));
+  const freq = params.get('freq');
+  if (freq) {
+    const radio = freqContainer.querySelector(`input[value="${freq}"]`);
+    if (radio) {
+      radio.checked = true;
+      state.frequency = freq;
+    }
+  }
+
+  update();
+
+  // handle add to cart
+  root.querySelector('[data-cm-form]').addEventListener('submit', async e => {
+    e.preventDefault();
+    if (!validate()) return;
+
+    const lines = [state.protein, state.side1, state.side2].map(id => ({
+      variant_id: id,
+      quantity: state.qty,
+      selling_plan_id: state.frequency || undefined
+    }));
+
+    for (const line of lines) {
+      await client.cart.addLineItem(line);
+    }
+
+    document.dispatchEvent(new CustomEvent('cart:refresh'));
+    addBtn.classList.add('is-added');
+  });
+}
+
+document.addEventListener('DOMContentLoaded', initBundleBuilder);

--- a/sections/product-cm-recharge.liquid
+++ b/sections/product-cm-recharge.liquid
@@ -1,0 +1,70 @@
+{%- comment -%}
+  Custom Meal builder powered by Recharge Storefront API.
+  Renders main content for product.cm-recharge template.
+{%- endcomment -%}
+
+{%- liquid
+  assign selling_plans = product.selling_plan_groups
+-%}
+
+<div class="cm-recharge" data-section-id="{{ section.id }}" data-protein-handle="recharge-cm-proteins" data-side-handle="recharge-cm-sides">
+  <div class="cm-recharge__intro">
+    <h1 class="cm-recharge__title">Build Custom Meals</h1>
+    <div class="cm-recharge__price-card">
+      <span class="cm-recharge__price" data-starting-price>Starting at {{ product.price | money_without_trailing_zeros }} – updates as you choose</span>
+    </div>
+    {%- if product.description != blank -%}
+      <div class="cm-recharge__description rte">{{ product.description }}</div>
+    {%- endif -%}
+  </div>
+
+  <form class="cm-recharge__form" data-cm-form>
+    <div class="cm-recharge__field">
+      <label for="cm-protein">Protein</label>
+      <select id="cm-protein" data-protein-select></select>
+    </div>
+    <div class="cm-recharge__field">
+      <label for="cm-side1">Side 1</label>
+      <select id="cm-side1" data-side1-select></select>
+    </div>
+    <div class="cm-recharge__field">
+      <label for="cm-side2">Side 2</label>
+      <select id="cm-side2" data-side2-select></select>
+    </div>
+    <div class="cm-recharge__field" data-seasoning-field hidden>
+      <label for="cm-seasoning">Seasoning (optional)</label>
+      <input id="cm-seasoning" type="text" data-seasoning-input>
+    </div>
+
+    <div class="cm-recharge__field">
+      <span>Delivery Frequency</span>
+      <div class="cm-recharge__frequency" data-frequency-options></div>
+    </div>
+
+    <div class="cm-recharge__actions">
+      <div class="cm-recharge__quantity" data-quantity-wrapper>
+        <button type="button" class="quantity-button" data-qty-minus aria-label="Decrease quantity">−</button>
+        <input type="number" min="1" value="1" readonly data-qty-input>
+        <button type="button" class="quantity-button" data-qty-plus aria-label="Increase quantity">+</button>
+      </div>
+      <button type="submit" class="button button--primary" data-add disabled>
+        <span>+ Add</span>
+      </button>
+    </div>
+
+    <div class="cm-recharge__total" data-total-price></div>
+    <div class="cm-recharge__error" data-error></div>
+  </form>
+</div>
+
+<script type="application/json" data-product-json>{{ product | json }}</script>
+<script type="application/json" data-selling-plans-json>{{ selling_plans | json }}</script>
+
+<link rel="stylesheet" href="{{ 'cm-recharge.css' | asset_url }}" media="print" onload="this.media='all'">
+<script type="module" src="{{ 'cm-recharge.js' | asset_url }}" defer></script>
+
+{% schema %}
+{
+  "name": "Custom Meal Recharge"
+}
+{% endschema %}

--- a/templates/product.cm-recharge.json
+++ b/templates/product.cm-recharge.json
@@ -1,0 +1,10 @@
+{
+  "layout": "product-shell",
+  "sections": {
+    "main": {
+      "type": "product-cm-recharge",
+      "settings": {}
+    }
+  },
+  "order": ["main"]
+}


### PR DESCRIPTION
## Summary
- add `product.cm-recharge` template based on existing with-sidebar layout
- implement `product-cm-recharge` section rendering Recharge bundle builder
- include `cm-recharge.js` leveraging Recharge Storefront SDK for bundle logic and `cm-recharge.css`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3172b968c832fbd09329baa0c4cd8