### PR TITLE
Load Recharge SDK for custom meal builder

### DIFF
--- a/sections/product-cm-recharge.liquid
+++ b/sections/product-cm-recharge.liquid
@@ -73,6 +73,8 @@
   {{ product.selling_plan_groups | json }}
 </script>
 
+<link rel="stylesheet" href="https://static.rechargecdn.com/assets/bundling-widget/src.css" referrerpolicy="origin">
+<script src="https://static.rechargecdn.com/assets/bundling-widget/src.js" referrerpolicy="origin"></script>
 <link rel="stylesheet" href="{{ 'cm-recharge.css' | asset_url }}">
 <script src="{{ 'cm-recharge.js' | asset_url }}" defer="defer"></script>
 


### PR DESCRIPTION
## Summary
- include Recharge bundling widget CSS and JS so `recharge` global is available for the custom meal builder

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3392a800c832f92c9a5b83ea4b593