### PR TITLE
Refine Recharge bundle integration for custom meal PDP

### DIFF
--- a/assets/cm-recharge.js
+++ b/assets/cm-recharge.js
@@ -1,15 +1,16 @@
 /*
-  REVISED - v4.1 (Bugfix Edition)
-  - Corrects the sellingPlan ID format (removes incorrect parseInt).
-  - Relies on globally initialized `recharge` object.
-  - Uses Shopify's products.json endpoint for fetching data.
-  - Implements the official recharge.bundle.getDynamicBundleItems workflow.
+  Custom Meal Recharge Bundle Builder
+  - Relies on the globally initialized Recharge Storefront SDK.
+  - Uses the documented recharge.bundle.getDynamicBundleItems flow.
+  - Adds robust validation, error handling, and plan matching for Shopify Checkout.
 */
 
 class CustomMealBuilder {
   constructor(element) {
     this.root = element;
     if (!this.root) return;
+    if (this.root.dataset.cmRechargeInitialized === 'true') return;
+    this.root.dataset.cmRechargeInitialized = 'true';
 
     // --- DOM Elements ---
     this.form = this.root.querySelector('[data-cm-form]');
@@ -22,31 +23,83 @@ class CustomMealBuilder {
     this.addToCartButton = this.root.querySelector('[data-add-to-cart-button]');
     this.addToCartText = this.root.querySelector('[data-add-to-cart-text]');
     this.errorMessage = this.root.querySelector('[data-error-message]');
-    
+    this.plusButton = this.root.querySelector('[data-qty-plus]');
+    this.minusButton = this.root.querySelector('[data-qty-minus]');
+
+    if (!this.form || !this.proteinSelect || !this.side1Select || !this.side2Select || !this.frequencySelect || !this.quantityInput || !this.addToCartButton || !this.addToCartText) {
+      console.error('CustomMealBuilder: required form controls are missing.');
+      return;
+    }
+
     // --- Data from Liquid ---
-    this.productHandle = this.root.dataset.productHandle;
+    this.sectionId = this.root.dataset.sectionId || '';
+    this.productHandle = this.root.dataset.productHandle || '';
     this.bundleProductId = this.root.dataset.bundleProductId;
     this.bundleVariantId = this.root.dataset.bundleVariantId;
-    this.proteinCollectionHandle = this.root.dataset.proteinCollectionHandle;
-    this.sideCollectionHandle = this.root.dataset.sideCollectionHandle;
+    this.proteinCollectionHandle = this.root.dataset.proteinCollectionHandle || '';
+    this.sideCollectionHandle = this.root.dataset.sideCollectionHandle || '';
     this.proteinCollectionId = this.root.dataset.proteinCollectionId;
     this.sideCollectionId = this.root.dataset.sideCollectionId;
-    this.sellingPlanGroups = JSON.parse(document.getElementById(`RechargeSellingPlans-${this.root.dataset.sectionId}`).textContent);
 
-    // --- State ---
+    const sellingPlanElement = document.getElementById(`RechargeSellingPlans-${this.sectionId}`);
+    try {
+      this.sellingPlanGroups = sellingPlanElement ? JSON.parse(sellingPlanElement.textContent || '[]') : [];
+      if (!Array.isArray(this.sellingPlanGroups)) {
+        this.sellingPlanGroups = [];
+      }
+    } catch (parseError) {
+      console.error('Failed to parse Recharge selling plans JSON:', parseError);
+      this.sellingPlanGroups = [];
+    }
+
+    // --- Derived state ---
     this.state = {
       quantity: 1,
       sellingPlanId: null,
       totalPrice: 0,
       isLoading: true,
     };
-    
-    document.addEventListener('DOMContentLoaded', () => this.initialize());
+
+    this.config = {
+      bundleProductId: null,
+      bundleVariantId: null,
+      proteinCollectionId: null,
+      sideCollectionId: null,
+    };
+
+    this.variantDetails = Object.create(null);
+
+    if (!this.ensureRequiredIds()) {
+      return;
+    }
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', () => this.initialize(), { once: true });
+    } else {
+      this.initialize();
+    }
+  }
+
+  ensureRequiredIds() {
+    try {
+      this.config.bundleProductId = this.parseNumericId(this.bundleProductId, 'Bundle product ID');
+      this.config.bundleVariantId = this.parseNumericId(this.bundleVariantId, 'Bundle variant ID');
+      this.config.proteinCollectionId = this.parseNumericId(this.proteinCollectionId, 'Protein collection ID');
+      this.config.sideCollectionId = this.parseNumericId(this.sideCollectionId, 'Side collection ID');
+      return true;
+    } catch (error) {
+      console.error('CustomMealBuilder configuration error:', error);
+      this.showError('Bundle configuration is incomplete. Please verify the assigned collections and variants.');
+      return false;
+    }
   }
 
   async initialize() {
-    if (typeof recharge === 'undefined' || typeof recharge.bundle === 'undefined') {
-      this.showError('Recharge SDK could not be loaded. Please check API Key and configuration.');
+    try {
+      await this.waitForRechargeBundle();
+    } catch (error) {
+      console.error('Recharge bundle failed to load:', error);
+      this.showError('Recharge SDK (recharge.bundle) not found. Please refresh the page or contact support.');
       return;
     }
 
@@ -58,18 +111,39 @@ class CustomMealBuilder {
         this.fetchCollectionProductsByHandle(this.proteinCollectionHandle),
         this.fetchCollectionProductsByHandle(this.sideCollectionHandle)
       ]);
-      
+
       this.populateSelect(this.proteinSelect, proteins, 'protein');
       this.populateSelect(this.side1Select, sides, 'side');
       this.populateSelect(this.side2Select, sides, 'side');
-      
+
       this.state.isLoading = false;
       this.update();
-
     } catch (error) {
       console.error('Failed to initialize Custom Meal Builder:', error);
       this.showError('Could not load meal options. Please check collection handles and refresh.');
     }
+  }
+
+  waitForRechargeBundle(timeout = 10000, interval = 50) {
+    return new Promise((resolve, reject) => {
+      const start = Date.now();
+
+      const checkBundle = () => {
+        if (typeof window !== 'undefined' && typeof window.recharge !== 'undefined' && typeof window.recharge.bundle !== 'undefined') {
+          resolve();
+          return;
+        }
+
+        if (Date.now() - start >= timeout) {
+          reject(new Error('recharge.bundle unavailable within timeout'));
+          return;
+        }
+
+        setTimeout(checkBundle, interval);
+      };
+
+      checkBundle();
+    });
   }
 
   bindEvents() {
@@ -79,161 +153,317 @@ class CustomMealBuilder {
     this.frequencySelect.addEventListener('change', () => this.update());
     this.quantityInput.addEventListener('change', () => this.update());
 
-    this.root.querySelector('[data-qty-plus]').addEventListener('click', () => { this.quantityInput.value++; this.update(); });
-    this.root.querySelector('[data-qty-minus]').addEventListener('click', () => { if (this.quantityInput.value > 1) { this.quantityInput.value--; this.update(); }});
+    if (this.plusButton) {
+      this.plusButton.addEventListener('click', () => {
+        this.quantityInput.value = String(this.state.quantity + 1);
+        this.update();
+      });
+    }
 
-    this.form.addEventListener('submit', (e) => this.handleAddToCart(e));
+    if (this.minusButton) {
+      this.minusButton.addEventListener('click', () => {
+        const nextValue = Math.max(1, this.state.quantity - 1);
+        this.quantityInput.value = String(nextValue);
+        this.update();
+      });
+    }
+
+    this.form.addEventListener('submit', (event) => this.handleAddToCart(event));
   }
-  
+
   async fetchCollectionProductsByHandle(handle) {
-    if (!handle) throw new Error(`Collection handle is missing.`);
+    if (!handle) throw new Error('Collection handle is missing.');
     const response = await fetch(`/collections/${handle}/products.json?limit=250`);
     if (!response.ok) throw new Error(`Failed to load collection: /collections/${handle}/products.json`);
     const data = await response.json();
-    return data.products || [];
+    return Array.isArray(data.products) ? data.products : [];
   }
 
   populateSelect(selectElement, products, type) {
+    if (!selectElement) return;
+
     selectElement.innerHTML = `<option value="">Choose a ${type}...</option>`;
-    products.forEach(product => {
-      product.variants.forEach(variant => {
+
+    products.forEach((product) => {
+      const productId = Number(product && product.id);
+      if (!Number.isFinite(productId)) return;
+
+      const variants = Array.isArray(product.variants) ? product.variants : [];
+      variants.forEach((variant) => {
+        const variantId = Number(variant && variant.id);
+        if (!Number.isFinite(variantId)) return;
+
         const option = document.createElement('option');
-        option.value = variant.id; // Use numeric ID for selection state
+        option.value = String(variantId);
         option.textContent = `${product.title} - ${variant.title}`;
-        option.dataset.price = Math.round(parseFloat(variant.price) * 100);
-        option.dataset.productId = product.id; // Store numeric product ID
-        option.dataset.variantId = variant.id; // Store numeric variant ID
+        option.dataset.price = String(this.toCents(variant.price));
         selectElement.appendChild(option);
+
+        this.variantDetails[String(variantId)] = {
+          productId,
+          variantId,
+          price: this.toCents(variant.price),
+          sellingPlanAllocations: this.normalizeSellingPlanAllocations(variant.selling_plan_allocations)
+        };
       });
     });
+
     selectElement.disabled = false;
   }
-  
+
   populateFrequencies() {
+    if (!this.frequencySelect) return;
     this.frequencySelect.innerHTML = '';
+
     const oneTimeOption = document.createElement('option');
-    oneTimeOption.value = "";
-    oneTimeOption.textContent = "One-time purchase";
+    oneTimeOption.value = '';
+    oneTimeOption.textContent = 'One-time purchase';
     this.frequencySelect.appendChild(oneTimeOption);
 
-    this.sellingPlanGroups.forEach(group => {
-      group.selling_plans.forEach(plan => {
+    this.sellingPlanGroups.forEach((group) => {
+      const plans = Array.isArray(group.selling_plans) ? group.selling_plans : [];
+      plans.forEach((plan) => {
+        if (!plan || !plan.id) return;
         const option = document.createElement('option');
-        option.value = plan.id; // This is the full GraphQL ID string
-        option.textContent = plan.name;
+        option.value = plan.id;
+        option.textContent = plan.name || 'Subscription';
         this.frequencySelect.appendChild(option);
       });
     });
+
     this.frequencySelect.disabled = false;
   }
 
   update() {
-    this.state.quantity = parseInt(this.quantityInput.value, 10);
-    this.state.sellingPlanId = this.frequencySelect.value || null; // This will be the string GID or null
+    const parsedQuantity = parseInt(this.quantityInput.value, 10);
+    this.state.quantity = Number.isFinite(parsedQuantity) && parsedQuantity > 0 ? parsedQuantity : 1;
+    this.quantityInput.value = String(this.state.quantity);
+
+    this.state.sellingPlanId = this.frequencySelect.value || null;
     this.calculatePrice();
     this.validate();
   }
 
   calculatePrice() {
-    let linePrice = 0;
     const getPrice = (select) => {
-      const selectedOption = select.options[select.selectedIndex];
-      return selectedOption ? parseFloat(selectedOption.dataset.price) || 0 : 0;
+      const option = select && select.options[select.selectedIndex];
+      const cents = option ? Number(option.dataset.price) : 0;
+      return Number.isFinite(cents) ? cents : 0;
     };
-    
-    linePrice += getPrice(this.proteinSelect);
-    linePrice += getPrice(this.side1Select);
-    linePrice += getPrice(this.side2Select);
-    
+
+    const linePrice = getPrice(this.proteinSelect) + getPrice(this.side1Select) + getPrice(this.side2Select);
     this.state.totalPrice = linePrice * this.state.quantity;
     this.priceDisplay.textContent = this.formatMoney(this.state.totalPrice);
   }
 
   validate() {
-    const isValid = this.proteinSelect.value && this.side1Select.value && this.side2Select.value;
-    this.addToCartButton.disabled = !isValid;
-    this.addToCartText.textContent = isValid ? 'Add to Cart' : 'Complete Your Meal';
-    if(isValid) this.errorMessage.textContent = '';
+    const hasSelections = Boolean(this.proteinSelect.value && this.side1Select.value && this.side2Select.value);
+    const canSubmit = hasSelections && !this.state.isLoading;
+
+    this.addToCartButton.disabled = !canSubmit;
+
+    if (this.state.isLoading) {
+      this.addToCartText.textContent = 'Loading...';
+    } else {
+      this.addToCartText.textContent = canSubmit ? 'Add to Cart' : 'Select Options';
+    }
+
+    if (canSubmit) {
+      this.errorMessage.textContent = '';
+    }
+  }
+
+  getSelectionDetails(selectElement) {
+    const variantId = selectElement.value;
+    if (!variantId) {
+      throw new Error('A required selection is missing.');
+    }
+
+    const details = this.variantDetails[variantId];
+    if (!details) {
+      throw new Error(`Missing variant metadata for ${variantId}.`);
+    }
+
+    return details;
+  }
+
+  buildSelection(variantDetails, collectionId) {
+    const selection = {
+      collectionId,
+      externalProductId: variantDetails.productId,
+      externalVariantId: variantDetails.variantId,
+      quantity: 1,
+    };
+
+    if (this.state.sellingPlanId) {
+      const matchedPlan = this.matchSellingPlan(variantDetails, this.state.sellingPlanId);
+
+      if (matchedPlan && matchedPlan.sellingPlanId) {
+        selection.sellingPlan = matchedPlan.sellingPlanId;
+      } else if (matchedPlan && matchedPlan.deliveryIntervalUnit && matchedPlan.deliveryIntervalFrequency) {
+        selection.shippingIntervalUnitType = matchedPlan.deliveryIntervalUnit;
+        selection.shippingIntervalFrequency = matchedPlan.deliveryIntervalFrequency;
+      } else {
+        selection.sellingPlan = this.state.sellingPlanId;
+      }
+    }
+
+    return selection;
   }
 
   async addItemsToCart(items, bundleQty = 1) {
     const lines = [];
-    for (let i = 0; i < bundleQty; i++) lines.push(...items);
-  
+    for (let i = 0; i < bundleQty; i += 1) {
+      lines.push(...items);
+    }
+
     const response = await fetch('/cart/add.js', {
       method: 'POST',
-      headers: {'Content-Type':'application/json'},
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ items: lines })
     });
-  
+
     if (!response.ok) {
+      let description = 'Failed to add items to cart.';
+      try {
         const errorData = await response.json();
-        throw new Error(errorData.description || 'Failed to add items to cart.');
+        if (errorData && errorData.description) {
+          description = errorData.description;
+        }
+      } catch (parseError) {
+        // ignore parse errors, keep default message
+      }
+      throw new Error(description);
     }
+
     document.dispatchEvent(new CustomEvent('cart:updated'));
   }
 
   async handleAddToCart(event) {
     event.preventDefault();
+    if (this.addToCartButton.disabled) return;
+
+    this.errorMessage.textContent = '';
     this.addToCartButton.disabled = true;
     this.addToCartText.textContent = 'Adding...';
 
-    const getSelectionData = (select) => {
-        const option = select.options[select.selectedIndex];
-        return {
-            productId: parseInt(option.dataset.productId),
-            variantId: parseInt(option.dataset.variantId)
-        };
-    };
-
-    const proteinData = getSelectionData(this.proteinSelect);
-    const side1Data = getSelectionData(this.side1Select);
-    const side2Data = getSelectionData(this.side2Select);
-    
-    // ** THE FIX IS HERE **
-    // The sellingPlan must be the full string GID, not an integer.
-    const sellingPlanForBundle = this.state.sellingPlanId ? this.state.sellingPlanId : null;
-
-    const bundle = {
-      externalProductId: parseInt(this.bundleProductId),
-      externalVariantId: parseInt(this.bundleVariantId),
-      selections: [
-        { collectionId: parseInt(this.proteinCollectionId), externalProductId: proteinData.productId, externalVariantId: proteinData.variantId, quantity: 1, sellingPlan: sellingPlanForBundle },
-        { collectionId: parseInt(this.sideCollectionId), externalProductId: side1Data.productId, externalVariantId: side1Data.variantId, quantity: 1, sellingPlan: sellingPlanForBundle },
-        { collectionId: parseInt(this.sideCollectionId), externalProductId: side2Data.productId, externalVariantId: side2Data.variantId, quantity: 1, sellingPlan: sellingPlanForBundle }
-      ]
-    };
-
     try {
+      const proteinDetails = this.getSelectionDetails(this.proteinSelect);
+      const side1Details = this.getSelectionDetails(this.side1Select);
+      const side2Details = this.getSelectionDetails(this.side2Select);
+
+      const bundle = {
+        externalProductId: this.config.bundleProductId,
+        externalVariantId: this.config.bundleVariantId,
+        selections: [
+          this.buildSelection(proteinDetails, this.config.proteinCollectionId),
+          this.buildSelection(side1Details, this.config.sideCollectionId),
+          this.buildSelection(side2Details, this.config.sideCollectionId)
+        ]
+      };
+
       const items = recharge.bundle.getDynamicBundleItems(bundle, this.productHandle);
       await this.addItemsToCart(items, this.state.quantity);
-      
+
       this.addToCartText.textContent = 'Added!';
       setTimeout(() => {
-        this.addToCartText.textContent = 'Add to Cart';
-        this.validate();
+        this.addToCartButton.disabled = false;
+        this.update();
       }, 2000);
-
-    } catch(error) {
+    } catch (error) {
       console.error('Failed to add bundle to cart:', error);
-      this.showError('There was an error adding to cart. Please try again.');
+      this.addToCartButton.disabled = false;
+      this.addToCartText.textContent = 'Add to Cart';
+      this.showError(error && error.message ? error.message : 'There was an error adding to cart. Please try again.', false);
       this.validate();
     }
   }
 
-  showError(message) {
-    this.errorMessage.textContent = message;
-    this.form.querySelectorAll('select, button, input').forEach(el => el.disabled = true);
+  showError(message, disableForm = true) {
+    if (this.errorMessage) {
+      this.errorMessage.textContent = message;
+    }
+
+    if (disableForm && this.form) {
+      const controls = this.form.querySelectorAll('select, button, input');
+      controls.forEach((control) => {
+        control.disabled = true;
+      });
+    }
   }
 
   formatMoney(cents) {
-    if (isNaN(cents)) return '';
+    if (!Number.isFinite(cents)) return '';
     const dollars = (cents / 100).toFixed(2);
     return `$${dollars}`;
   }
+
+  toCents(value) {
+    const amount = typeof value === 'number' ? value : parseFloat(value);
+    if (!Number.isFinite(amount)) return 0;
+    return Math.round(amount * 100);
+  }
+
+  parseNumericId(value, label) {
+    if (value === undefined || value === null || value === '') {
+      throw new Error(`${label} is missing.`);
+    }
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      throw new Error(`${label} is invalid.`);
+    }
+    return parsed;
+  }
+
+  normalizeSellingPlanAllocations(allocations) {
+    if (!Array.isArray(allocations)) return [];
+
+    return allocations.map((allocation) => {
+      const sellingPlan = allocation && allocation.selling_plan ? allocation.selling_plan : {};
+      const deliveryPolicy = allocation && allocation.delivery_policy ? allocation.delivery_policy : sellingPlan && sellingPlan.delivery_policy ? sellingPlan.delivery_policy : {};
+
+      return {
+        sellingPlanId: allocation && allocation.selling_plan_id != null ? String(allocation.selling_plan_id) : (sellingPlan && sellingPlan.id ? String(sellingPlan.id) : null),
+        deliveryIntervalUnit: deliveryPolicy && (deliveryPolicy.interval_unit || deliveryPolicy.interval_unit_type || deliveryPolicy.frequency_unit || deliveryPolicy.unit) || null,
+        deliveryIntervalFrequency: deliveryPolicy && (deliveryPolicy.interval_count || deliveryPolicy.interval_frequency || deliveryPolicy.frequency) || null,
+      };
+    });
+  }
+
+  matchSellingPlan(variantDetails, sellingPlanId) {
+    if (!sellingPlanId || !variantDetails || !Array.isArray(variantDetails.sellingPlanAllocations)) return null;
+    const target = String(sellingPlanId);
+    const comparableTarget = this.extractComparablePlanId(target);
+
+    for (const allocation of variantDetails.sellingPlanAllocations) {
+      if (!allocation) continue;
+      const planId = allocation.sellingPlanId ? String(allocation.sellingPlanId) : '';
+      if (!planId) continue;
+      const comparablePlanId = this.extractComparablePlanId(planId);
+      if (planId === target || comparablePlanId === comparableTarget) {
+        return allocation;
+      }
+    }
+
+    return null;
+  }
+
+  extractComparablePlanId(value) {
+    if (!value) return '';
+    const stringValue = String(value);
+    if (stringValue.indexOf('/') === -1) return stringValue;
+    const segments = stringValue.split('/');
+    return segments[segments.length - 1];
+  }
 }
 
-const builderElement = document.querySelector('.cm-recharge');
-if (builderElement) {
-  new CustomMealBuilder(builderElement);
-}
+const initCustomMealBuilders = (scope = document) => {
+  if (!scope || typeof scope.querySelectorAll !== 'function') return;
+  scope.querySelectorAll('.cm-recharge').forEach((element) => new CustomMealBuilder(element));
+};
+
+initCustomMealBuilders();
+
+document.addEventListener('shopify:section:load', (event) => {
+  initCustomMealBuilders(event.target);
+});

--- a/layout/product-shell.liquid
+++ b/layout/product-shell.liquid
@@ -166,7 +166,38 @@
 
 	<link rel="sitemap" type="application/xml" title="Sitemap" href="/sitemap.xml" />
 
-	{% render 'treedify' %}{{ content_for_header }}
+        {% render 'treedify' %}{{ content_for_header }}
+  {%- comment -%}
+  =====================================================================================
+  Recharge Storefront SDK - Global Loader (Product Shell Layout)
+  Mirrors the loader in layout/theme.liquid so sections like `product-cm-recharge`
+  can rely on the Recharge SDK being present when this alternate layout is used.
+  =====================================================================================
+  {%- endcomment -%}
+  {% if settings.recharge_storefront_access_token != blank %}
+    <script src="https://static.rechargecdn.com/assets/storefront/recharge-client-1.47.0.min.js"></script>
+    <script>
+      (function initializeRecharge() {
+        if (window.__rechargeInitialized) return;
+        if (typeof recharge === 'undefined' || typeof recharge.init !== 'function') return;
+
+        recharge.init({
+          storeIdentifier: "{{ shop.permanent_domain }}",
+          storefrontAccessToken: "{{ settings.recharge_storefront_access_token }}",
+          appName: "ICON Meals CM PDP",
+          appVersion: "1.0.0",
+          loginRetryFn: function () {
+            if (recharge && recharge.auth && typeof recharge.auth.loginShopifyAppProxy === 'function') {
+              return recharge.auth.loginShopifyAppProxy();
+            }
+            return Promise.resolve();
+          }
+        });
+
+        window.__rechargeInitialized = true;
+      })();
+    </script>
+  {% endif %}
 {%- render 'bold-options-hybrid' -%}
 {%- render 'bold-common' -%}
 {%- render 'sc-includes' -%}

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -89,25 +89,39 @@
 
 	<link rel="sitemap" type="application/xml" title="Sitemap" href="/sitemap.xml" />
 
-	{% render 'treedify' %}{{ content_for_header }}
+        {% render 'treedify' %}{{ content_for_header }}
   {%- comment -%}
   =====================================================================================
   Recharge Storefront SDK - Global Loader
   - Loads the official UMD script from the Recharge CDN.
   - Initializes the SDK globally with the Storefront Access Token from Theme Settings.
+  - Uses a guard so the client only initializes once per page load.
   =====================================================================================
 {%- endcomment -%}
-<script src="https://static.rechargecdn.com/assets/storefront/recharge-client-1.47.0.min.js"></script>
-<script>
-  if (typeof recharge !== 'undefined' && typeof recharge.init === 'function') {
-    recharge.init({
-      storeIdentifier: "{{ shop.permanent_domain }}",
-      storefrontAccessToken: "{{ settings.recharge_storefront_access_token }}",
-      appName: "ICON Meals CM PDP",
-      appVersion: "1.0.0"
-    });
-  }
-</script>
+{% if settings.recharge_storefront_access_token != blank %}
+  <script src="https://static.rechargecdn.com/assets/storefront/recharge-client-1.47.0.min.js"></script>
+  <script>
+    (function initializeRecharge() {
+      if (window.__rechargeInitialized) return;
+      if (typeof recharge === 'undefined' || typeof recharge.init !== 'function') return;
+
+      recharge.init({
+        storeIdentifier: "{{ shop.permanent_domain }}",
+        storefrontAccessToken: "{{ settings.recharge_storefront_access_token }}",
+        appName: "ICON Meals CM PDP",
+        appVersion: "1.0.0",
+        loginRetryFn: function () {
+          if (recharge && recharge.auth && typeof recharge.auth.loginShopifyAppProxy === 'function') {
+            return recharge.auth.loginShopifyAppProxy();
+          }
+          return Promise.resolve();
+        }
+      });
+
+      window.__rechargeInitialized = true;
+    })();
+  </script>
+{% endif %}
 {%- render 'bold-options-hybrid' -%}
 {%- render 'bold-common' -%}
 {%- render 'sc-includes' -%}

--- a/sections/product-cm-recharge.liquid
+++ b/sections/product-cm-recharge.liquid
@@ -1,7 +1,11 @@
 {% comment %}
-  REVISED - v4.0
-  This version uses the globally loaded Recharge SDK and passes all necessary numeric IDs for the modern add-to-cart workflow.
+  Custom Meal Recharge PDP
+  - Relies on the globally initialized Recharge Storefront SDK.
+  - Exposes bundle + collection identifiers for the JavaScript controller.
 {% endcomment %}
+
+{% assign protein_collection = collections[section.settings.protein_collection_handle] %}
+{% assign side_collection = collections[section.settings.side_collection_handle] %}
 
 <div 
   id="cm-recharge-root-{{ section.id }}"
@@ -12,8 +16,8 @@
   data-bundle-variant-id="{{ product.selected_or_first_available_variant.id }}"
   data-protein-collection-handle="{{ section.settings.protein_collection_handle }}"
   data-side-collection-handle="{{ section.settings.side_collection_handle }}"
-  data-protein-collection-id="{{ collections[section.settings.protein_collection_handle].id }}"
-  data-side-collection-id="{{ collections[section.settings.side_collection_handle].id }}"
+  data-protein-collection-id="{{ protein_collection.id | default: '' }}"
+  data-side-collection-id="{{ side_collection.id | default: '' }}"
 >
   <div class="cm-recharge__intro">
     <h1 class="cm-recharge__title">{{ product.title | escape }}</h1>
@@ -71,6 +75,27 @@
 
 <script id="RechargeSellingPlans-{{ section.id }}" type="application/json">
   {{ product.selling_plan_groups | json }}
+</script>
+
+<script>
+  (function loadRechargeBundleScript() {
+    if (window.__iconRechargeBundleScriptRequested) return;
+    if (typeof window.recharge !== 'undefined' && typeof window.recharge.bundle !== 'undefined') return;
+
+    var existingScript = document.querySelector('script[data-icon-recharge-bundle]');
+    if (existingScript) {
+      window.__iconRechargeBundleScriptRequested = true;
+      return;
+    }
+
+    window.__iconRechargeBundleScriptRequested = true;
+    var script = document.createElement('script');
+    script.src = 'https://static.rechargecdn.com/assets/bundling-widget/src.js';
+    script.defer = true;
+    script.referrerPolicy = 'origin';
+    script.setAttribute('data-icon-recharge-bundle', 'true');
+    document.head.appendChild(script);
+  })();
 </script>
 
 <link rel="stylesheet" href="{{ 'cm-recharge.css' | asset_url }}">


### PR DESCRIPTION
## Summary
- guard the Recharge SDK loader in both theme layouts so it initializes once with an optional login retry fallback
- expose bundle and collection identifiers from the custom meal section while only loading the bundling widget script a single time
- overhaul cm-recharge.js to cache variant metadata, match selling plans, and submit bundles through recharge.bundle.getDynamicBundleItems before posting to /cart/add.js

## Testing
- not run (Shopify theme changes)

------
https://chatgpt.com/codex/tasks/task_e_68c99386e1ec832f80cf1eb040492f87