### PR TITLE
Fix hero media display on Custom Meal Recharge template

### DIFF
--- a/assets/cm-recharge.css
+++ b/assets/cm-recharge.css
@@ -123,10 +123,36 @@
   object-fit: contain !important;
   background: transparent;
 }
+.cm-recharge__media-frame {
+  width: 100%;
+  position: relative;
+}
+.cm-recharge__media-frame > * {
+  width: 100%;
+}
+.cm-recharge__media-video,
+.cm-recharge__media-model,
+.cm-recharge__media-generic {
+  display: block;
+}
+.cm-recharge__media video,
+.cm-recharge__media iframe,
+.cm-recharge__media model-viewer,
+.cm-recharge__media .shopify-model-viewer-ui {
+  width: 100%;
+  max-width: 100%;
+  height: auto;
+  background: transparent;
+}
+.cm-recharge__media-placeholder svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
 .cm-recharge__media .card,
-.cm-recharge__media .card--soft { 
-  padding: 0 !important; 
-  box-shadow: none !important; 
+.cm-recharge__media .card--soft {
+  padding: 0 !important;
+  box-shadow: none !important;
 }
 @media (min-width: 990px){
   .cm-recharge__media { max-width: 620px; }

--- a/sections/product-cm-recharge.liquid
+++ b/sections/product-cm-recharge.liquid
@@ -25,9 +25,44 @@
 >
   <div class="product-page container">
     <div class="product-page__grid">
+      {% liquid
+        assign hero_media = product.selected_or_first_available_variant.featured_media | default: product.featured_media
+        if hero_media == blank and product.media.size > 0
+          assign hero_media = product.media.first
+        endif
+      %}
+
       <!-- LEFT: Media / Hero Image -->
       <section class="product-page__media cm-recharge__media card card--soft">
-        {% render 'product-media', product: product, media_layout: 'single' %}
+        {% if hero_media %}
+          {% assign hero_alt = hero_media.alt | default: product.title %}
+          <div class="cm-recharge__media-frame">
+            {% case hero_media.media_type %}
+              {% when 'image' %}
+                {% render 'responsive-image' with hero_media, class: 'cm-recharge__image', alt: hero_alt, default_size: '1024x', blur: false %}
+              {% when 'external_video' %}
+                <div class="cm-recharge__media-video">
+                  {{ hero_media | external_video_tag: class: 'cm-recharge__external-video' }}
+                </div>
+              {% when 'video' %}
+                <div class="cm-recharge__media-video">
+                  {{ hero_media | video_tag: controls: true, playsinline: true, class: 'cm-recharge__video' }}
+                </div>
+              {% when 'model' %}
+                <div class="cm-recharge__media-model">
+                  {{ hero_media | model_viewer_tag: class: 'cm-recharge__model-viewer', reveal: 'interaction', toggleable: true, image_size: "1024x", data-model-id: hero_media.id }}
+                </div>
+              {% else %}
+                <div class="cm-recharge__media-generic">
+                  {{ hero_media | media_tag }}
+                </div>
+            {% endcase %}
+          </div>
+        {% else %}
+          <div class="cm-recharge__media-placeholder">
+            {{ 'product-1' | placeholder_svg_tag: 'icon--placeholder' }}
+          </div>
+        {% endif %}
       </section>
 
       <!-- RIGHT: Builder Panel -->


### PR DESCRIPTION
## Summary
- render the selected or featured product media directly on the Custom Meal Recharge template so the hero asset displays without forced padding
- handle images, videos, models, and fall back to a placeholder when no media exists
- add scoped styles that size the new media wrappers and embeds to fill the card without extra padding

## Testing
- not run (theme files)


------
https://chatgpt.com/codex/tasks/task_e_68c9d0e06cb8832f83c18055ebb1396a