### PR TITLE
Set CM recharge default price display to zero

### DIFF
--- a/sections/product-cm-recharge.liquid
+++ b/sections/product-cm-recharge.liquid
@@ -72,7 +72,7 @@
           <div class="product-price--placeholder">
             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="2" width="16" height="20" rx="2" ry="2"></rect><line x1="8" y1="6" x2="16" y2="6"></line><line x1="16" y1="14" x2="16" y2="18"></line><line x1="12" y1="14" x2="12" y2="18"></line><line x1="8" y1="14" x2="8" y2="18"></line><line x1="8" y1="10" x2="16" y2="10"></line></svg>
             <div>
-              <span class="placeholder-main-text" data-total-price>{{ product.price | money_without_trailing_zeros }}</span>
+              <span class="placeholder-main-text" data-total-price>{{ 0 | money }}</span>
               <span class="placeholder-sub-text">Your total will update here.</span>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- default the CM recharge hero price display to $0.00 instead of the product's base price
- keep the placeholder text ready for the JS bundle builder to update once selections are made

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ca9fe96ac8832fb57e5f0543c4eb62