### PR TITLE
Align Custom Meal Recharge layout with standard product pages

### DIFF
--- a/assets/cm-recharge.css
+++ b/assets/cm-recharge.css
@@ -8,8 +8,11 @@
 */
 
 /* --- Main Layout --- */
-.product-page__grid { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1.1fr); gap: 3rem; align-items: flex-start; }
-.cm-recharge__panel { display: flex; flex-direction: column; gap: 1.5rem; padding-top: 0.5rem; }
+.cm-recharge__main { padding: 1.5rem 0; }
+.cm-recharge__layout { display: flex; flex-direction: column; gap: 1.5rem; }
+.cm-recharge__visuals,
+.cm-recharge__panel { display: flex; flex-direction: column; gap: 1.5rem; }
+.cm-recharge__panel { padding-top: 0.5rem; }
 
 /* --- Header & Description --- */
 .cm-recharge__intro .h2 { font-size: 2.25rem !important; font-weight: 800 !important; margin-bottom: 1rem; }
@@ -127,7 +130,7 @@
 .cm-recharge__cta { display: grid; grid-template-columns: auto 1fr; gap: 0.75rem; align-items: center; margin-top: 1.5rem; }
 .cm-recharge__cta .product-card__add-btn { width: 100% !important; height: 48px; }
 .cm-recharge__error { color: #c01923; margin-top: 0.75rem; font-size: 0.9rem; font-weight: 500; }
-.cm-recharge__media { align-self: start; position: sticky; top: 100px; }
+.cm-recharge__media { align-self: stretch; position: relative; top: auto; }
 .cm-recharge__media img { display: block; width: 100%; height: auto !important; object-fit: contain !important; background: transparent; }
 .cm-recharge__cta .integrated-quantity { display: flex; height: 48px; }
 .cm-recharge__cta .integrated-quantity__button { width: 48px; background-color: var(--brand-accent); border: 1px solid var(--brand-accent); color: #fff; font-size: 1.2rem; cursor: pointer; display: flex; align-items: center; justify-content: center; }
@@ -136,8 +139,13 @@
 .cm-recharge__cta .integrated-quantity__input { width: 52px; text-align: center; border: 1px solid #ced4da; border-left: none; border-right: none; background: #fff !important; color: #111 !important; font-weight: 600; -moz-appearance: textfield; height:100%; }
 
 /* --- Responsive Overrides --- */
-@media (max-width: 990px) {
-  .product-page__grid { grid-template-columns: 1fr; gap: 2rem; }
+@media (min-width: 1024px) {
+  .cm-recharge__layout { display: grid; grid-template-columns: 45fr 55fr; gap: 3rem; align-items: flex-start; }
+  .cm-recharge__visuals { position: sticky; top: 1.5rem; }
+  .cm-recharge__panel { padding-top: 0; }
+}
+
+@media (max-width: 1023px) {
   .cm-recharge__media { order: -1; position: static; top: auto; }
   .cm-recharge__panel { padding-top: 0; }
 }

--- a/assets/macro-calculator-v2.css
+++ b/assets/macro-calculator-v2.css
@@ -1,51 +1,32 @@
 #nutrition-container-v2 {
   margin-top: 1.5rem;
-  /* *** FIX: Add position and z-index to ensure it renders above sticky elements *** */
-  position: relative;
-  z-index: 2;
 }
 
-#nutrition-container-v2 .macro-panel {
-  background: #ffffff;
-  border: 1px solid rgba(17, 24, 39, 0.08);
-  border-radius: 12px;
-  padding: 1.5rem;
-  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
+#nutrition-container-v2 .nutrition-panel-v8 {
+  width: 100%;
 }
 
-#nutrition-container-v2 .macro-panel__header {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
+#nutrition-container-v2 .panel-body {
+  border-top: 1px solid #e9ecef;
+  background-color: #ffffff;
+  padding: 1.25rem 1.5rem;
 }
 
-#nutrition-container-v2 .macro-panel__title {
-  font-size: 1.2rem;
-  font-weight: 600;
-  margin: 0;
-  color: #111827;
-}
-
-#nutrition-container-v2 .macro-panel__status {
-  font-size: 0.85rem;
-  font-weight: 500;
-  color: #16a34a;
-  background: rgba(22, 163, 74, 0.12);
-  border-radius: 9999px;
-  padding: 0.25rem 0.75rem;
+#nutrition-container-v2 .panel-body-title {
+  margin: 0 0 1rem 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #212529;
+  letter-spacing: 0.05em;
   text-transform: uppercase;
-  letter-spacing: 0.04em;
 }
 
-#nutrition-container-v2 .macro-panel__empty {
-  font-size: 0.95rem;
-  color: #4b5563;
+#nutrition-container-v2 .panel-empty-message {
   margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: #495057;
+  text-align: center;
 }
 
 #nutrition-container-v2 .macro-panel__table {
@@ -55,7 +36,7 @@
 
 #nutrition-container-v2 .macro-panel__grid {
   display: grid;
-  grid-template-columns: minmax(160px, 2fr) repeat(6, minmax(90px, 1fr));
+  grid-template-columns: minmax(180px, 2fr) repeat(6, minmax(90px, 1fr));
   gap: 0.75rem;
   align-items: stretch;
 }
@@ -66,7 +47,8 @@
 
 #nutrition-container-v2 .macro-panel__cell {
   padding: 0.75rem;
-  background: #f9fafb;
+  background-color: #f8f9fa;
+  border: 1px solid #e9ecef;
   border-radius: 8px;
   font-size: 0.9rem;
   font-weight: 500;
@@ -90,7 +72,7 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: #6b7280;
+  color: #6c757d;
 }
 
 #nutrition-container-v2 .macro-panel__item-name {
@@ -105,8 +87,9 @@
 }
 
 #nutrition-container-v2 .macro-panel__row--header .macro-panel__cell {
-  background: #111827;
-  color: #f9fafb;
+  background-color: #111827;
+  border-color: #111827;
+  color: #f8f9fa;
   font-weight: 600;
   text-transform: uppercase;
   font-size: 0.75rem;
@@ -114,7 +97,8 @@
 }
 
 #nutrition-container-v2 .macro-panel__row--total .macro-panel__cell {
-  background: #e0f2fe;
+  background-color: #e0f2fe;
+  border-color: #cfe1f5;
   color: #0f172a;
   font-weight: 700;
 }
@@ -136,66 +120,47 @@
   font-size: 0.7rem;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: #6b7280;
-}
-
-#nutrition-container-v2 .macro-panel--empty .macro-panel__grid {
-  display: none;
-}
-
-#nutrition-container-v2 .macro-panel--empty {
-  align-items: flex-start;
-}
-
-#nutrition-container-v2 .macro-panel__body {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
+  color: #6c757d;
 }
 
 #nutrition-container-v2 .macro-panel__footnote {
+  margin-top: 1rem;
   font-size: 0.75rem;
-  color: #9ca3af;
+  color: #6c757d;
 }
 
-@media (max-width: 900px) {
+#nutrition-container-v2 .nutrition-panel-v8--empty .panel-body {
+  padding: 1.5rem;
+}
+
+#nutrition-container-v2 .nutrition-panel-v8--empty .panel-body::before {
+  content: '';
+  display: block;
+  width: 48px;
+  height: 4px;
+  margin: 0 auto 1rem auto;
+  background: #e9ecef;
+  border-radius: 999px;
+}
+
+@media (max-width: 1023px) {
   #nutrition-container-v2 .macro-panel__grid {
-    grid-template-columns: minmax(160px, 2fr) repeat(3, minmax(90px, 1fr));
-  }
-
-  #nutrition-container-v2 .macro-panel__grid[data-columns="7"] {
-    grid-template-columns: minmax(160px, 2fr) repeat(3, minmax(90px, 1fr));
-  }
-
-  #nutrition-container-v2 .macro-panel__grid::-webkit-scrollbar {
-    height: 6px;
-  }
-
-  #nutrition-container-v2 .macro-panel__grid::-webkit-scrollbar-thumb {
-    background: rgba(156, 163, 175, 0.6);
-    border-radius: 9999px;
+    grid-template-columns: minmax(160px, 2fr) repeat(6, minmax(80px, 1fr));
   }
 }
 
 @media (max-width: 640px) {
-  #nutrition-container-v2 {
-    margin-top: 1rem;
+  #nutrition-container-v2 .panel-body {
+    padding: 1.25rem 1rem;
   }
 
-  #nutrition-container-v2 .macro-panel {
-    padding: 1.25rem;
-  }
-
-  #nutrition-container-v2 .macro-panel__title {
-    font-size: 1.05rem;
-  }
-
-  #nutrition-container-v2 .macro-panel__status {
-    font-size: 0.75rem;
+  #nutrition-container-v2 .macro-panel__grid {
+    grid-template-columns: minmax(160px, 1.5fr) repeat(6, minmax(70px, 1fr));
+    gap: 0.5rem;
   }
 
   #nutrition-container-v2 .macro-panel__cell {
+    padding: 0.6rem;
     font-size: 0.85rem;
-    padding: 0.65rem;
   }
 }

--- a/assets/macro-calculator-v2.js.liquid
+++ b/assets/macro-calculator-v2.js.liquid
@@ -32,6 +32,14 @@
     "suffix": "mg"
   }
 ];
+  const MACRO_CLASS_MAP = {
+    calorie: 'calories',
+    protein: 'protein',
+    carb: 'carbs',
+    fat: 'fats',
+    fiber: 'fiber',
+    sodium: 'sodium'
+  };
   const NUTRITION_DATA = {
   "black bean vegan patty": {
     "calorie": 150,
@@ -456,8 +464,6 @@
   "patty": "each",
   "patties": "each"
 };
-  const STATUS_LABEL = 'Live preview';
-
   const api = window.iconMacroV2 = window.iconMacroV2 || {};
 
   const ESCAPE_LOOKUP = {
@@ -470,6 +476,38 @@
 
   function getContainer() {
     return document.getElementById(containerId);
+  }
+
+  function decorateContainer(container) {
+    if (!container) return;
+    container.classList.add('nutrition-container-v8');
+    if (!container.dataset.toggleBound) {
+      container.addEventListener('click', handlePanelToggle, false);
+      container.dataset.toggleBound = 'true';
+    }
+  }
+
+  function handlePanelToggle(event) {
+    const toggle = event.target.closest('.panel-toggle-primary');
+    if (!toggle) return;
+
+    event.preventDefault();
+
+    const panel = toggle.closest('.nutrition-panel-v8');
+    if (!panel) return;
+
+    const body = panel.querySelector('.panel-body');
+    if (!body) return;
+
+    const nextExpanded = !panel.classList.contains('is-expanded');
+    panel.classList.toggle('is-expanded', nextExpanded);
+    body.classList.toggle('is-hidden', !nextExpanded);
+
+    toggle.setAttribute('aria-expanded', nextExpanded ? 'true' : 'false');
+    const textNode = toggle.querySelector('.toggle-text');
+    if (textNode) {
+      textNode.textContent = nextExpanded ? 'Less Info' : 'More Info';
+    }
   }
 
   function escapeHtml(value) {
@@ -627,18 +665,20 @@
   }
 
   function renderEmpty(container) {
+    decorateContainer(container);
+    container.style.display = 'block';
     container.innerHTML = `
-      <div class="macro-panel macro-panel--empty">
-        <div class="macro-panel__header">
-          <h3 class="macro-panel__title">Meal Nutrition</h3>
-          <span class="macro-panel__status">${escapeHtml(STATUS_LABEL)}<\/span>
+      <div class="nutrition-panel-v8 nutrition-panel-v8--empty">
+        <div class="panel-body">
+          <p class="panel-empty-message">Select items to build your meal and see nutritional info.<\/p>
         </div>
-        <p class="macro-panel__empty">Select items to build your meal and see nutritional info.<\/p>
       </div>
     `;
   }
 
   function renderPanel(container, items) {
+    decorateContainer(container);
+
     const totals = {};
     MACRO_FIELDS.forEach(field => { totals[field.key] = 0; });
 
@@ -648,6 +688,14 @@
         totals[field.key] += item.macros[field.key];
       });
     });
+
+    const macroStatsHtml = MACRO_FIELDS.map(field => {
+      const classSuffix = MACRO_CLASS_MAP[field.key] || field.key;
+      const formattedValue = formatNumber(totals[field.key]);
+      const suffix = field.suffix || '';
+      const displayValue = suffix ? `${formattedValue}${suffix}` : formattedValue;
+      return `<div class="macro-stat macro-stat--${classSuffix}"><span class="macro-stat__value">${escapeHtml(displayValue)}<\/span><span class="macro-stat__label">${escapeHtml(field.label)}<\/span></div>`;
+    }).join('');
 
     const headerCells = [
       '<div class="macro-panel__cell macro-panel__cell--item">Item<\/div>'
@@ -705,16 +753,20 @@
     });
 
     const totalRow = `<div class="macro-panel__row macro-panel__row--total">${totalCells.join('')}<\/div>`;
-
     const columnCount = 1 + MACRO_FIELDS.length;
 
+    container.style.display = 'block';
     container.innerHTML = `
-      <div class="macro-panel">
-        <div class="macro-panel__header">
-          <h3 class="macro-panel__title">Meal Nutrition</h3>
-          <span class="macro-panel__status">${escapeHtml(STATUS_LABEL)}<\/span>
+      <div class="nutrition-panel-v8">
+        <div class="macro-grid--interactive">${macroStatsHtml}</div>
+        <div class="panel-footer">
+          <a href="#" class="panel-toggle-primary" role="button" aria-expanded="false">
+            <span class="toggle-text">More Info</span>
+            <span class="toggle-icon"></span>
+          </a>
         </div>
-        <div class="macro-panel__body">
+        <div class="panel-body is-hidden">
+          <h4 class="panel-body-title">Ingredient Breakdown</h4>
           <div class="macro-panel__table">
             <div class="macro-panel__grid" data-columns="${columnCount}">
               ${headerRow}${itemRows}${totalRow}

--- a/sections/product-cm-recharge.liquid
+++ b/sections/product-cm-recharge.liquid
@@ -12,7 +12,7 @@
 
 <div
   id="cm-recharge-root-{{ section.id }}"
-  class="cm-recharge product product--with-sidebar product-template"
+  class="cm-recharge product product-template"
   data-section-id="{{ section.id }}"
   data-product-handle="{{ product.handle }}"
   data-bundle-product-id="{{ product.id }}"
@@ -22,8 +22,8 @@
   data-protein-collection-id="{{ protein_collection.id | default: '' }}"
   data-side-collection-id="{{ side_collection.id | default: '' }}"
 >
-  <div class="product-page container">
-    <div class="product-page__grid">
+  <div class="product-main cm-recharge__main container">
+    <div class="product-main__layout cm-recharge__layout">
       {% liquid
         assign hero_media = product.selected_or_first_available_variant.featured_media | default: product.featured_media
         if hero_media == blank and product.media.size > 0
@@ -32,9 +32,9 @@
       %}
 
       <!-- Wrapper for Left Column Content -->
-      <div>
+      <div class="product-main__visuals-wrapper cm-recharge__visuals">
         <!-- LEFT: Media / Hero Image -->
-        <section class="product-page__media cm-recharge__media card card--soft">
+        <section class="product-main__gallery cm-recharge__media card card--soft">
           {% if hero_media %}
             {% assign hero_alt = hero_media.alt | default: product.title %}
             <div class="cm-recharge__media-frame">
@@ -55,12 +55,12 @@
         </section>
 
         <!-- Nutrition Calculator (Now correctly positioned below the image) -->
-        <div id="nutrition-container-v2" class="cm-recharge-macro-container"></div>
+        <div id="nutrition-container-v2" class="cm-recharge-macro-container nutrition-container-v8"></div>
       </div>
 
 
       <!-- RIGHT: Builder Panel -->
-      <section class="product-page__details cm-recharge__panel">
+      <section class="product-main__info-column cm-recharge__panel">
         <div class="cm-recharge__intro">
           <h1 class="cm-recharge__title h2">{{ product.title | escape }}</h1>
           <div class="product-price--placeholder">


### PR DESCRIPTION
## Summary
- restructure the Custom Meal Recharge section to use the product-main layout for consistent media and form positioning
- restyle the macro calculator output to reuse the nutrition panel v8 presentation and integrate the detailed breakdown into the toggleable body
- refresh supporting CSS for the recharge layout and macro breakdown table so the page spacing and styling match existing product pages

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cbfe96e5f0832f93e01f3357949a3c