### PR TITLE
Align recharge recharge layout with product main styling

### DIFF
--- a/assets/cm-recharge.css
+++ b/assets/cm-recharge.css
@@ -9,12 +9,18 @@
 
 /* --- Main Layout --- */
 .cm-recharge__main { padding: 1.5rem 0; }
-.cm-recharge__layout { display: flex; flex-direction: column; gap: 1.5rem; }
+.cm-recharge__layout {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 1.5rem 1.2rem;
+}
 .cm-recharge__visuals {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
-  min-width: 0; /* FIX: Prevents wide children (e.g., nutrition table) from breaking the grid layout. */
+  min-width: 0; /* Prevents wide children (e.g., nutrition table) from breaking the grid layout. */
+  align-items: stretch;
 }
 .cm-recharge__panel {
   display: flex;
@@ -139,8 +145,34 @@
 .cm-recharge__cta { display: grid; grid-template-columns: auto 1fr; gap: 0.75rem; align-items: center; margin-top: 1.5rem; }
 .cm-recharge__cta .product-card__add-btn { width: 100% !important; height: 48px; }
 .cm-recharge__error { color: #c01923; margin-top: 0.75rem; font-size: 0.9rem; font-weight: 500; }
-.cm-recharge__media { align-self: stretch; position: relative; top: auto; }
-.cm-recharge__media img { display: block; width: 100%; height: auto !important; object-fit: contain !important; background: transparent; }
+.cm-recharge__media {
+  align-self: stretch;
+  position: relative;
+  top: auto;
+  padding: 0;
+  background: transparent;
+  border: none;
+  box-shadow: none;
+}
+.cm-recharge__media-frame,
+.cm-recharge__media-placeholder,
+.cm-recharge__media-generic {
+  border-radius: 12px;
+  border: 1px solid #e9ecef;
+  overflow: hidden;
+  background: #fff;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+}
+.cm-recharge__media img {
+  display: block;
+  width: 100%;
+  height: auto !important;
+  object-fit: contain !important;
+  background: transparent;
+  border-radius: 12px;
+  border: none;
+  box-shadow: none;
+}
 .cm-recharge__cta .integrated-quantity { display: flex; height: 48px; }
 .cm-recharge__cta .integrated-quantity__button { width: 48px; background-color: var(--brand-accent); border: 1px solid var(--brand-accent); color: #fff; font-size: 1.2rem; cursor: pointer; display: flex; align-items: center; justify-content: center; }
 .cm-recharge__cta .integrated-quantity__button[data-qty-minus] { border-radius: 8px 0 0 8px; }
@@ -149,12 +181,28 @@
 
 /* --- Responsive Overrides --- */
 @media (min-width: 1024px) {
-  .cm-recharge__layout { display: grid; grid-template-columns: 45fr 55fr; gap: 3rem; align-items: flex-start; }
-  .cm-recharge__visuals { position: sticky; top: 1.5rem; }
-  .cm-recharge__panel { padding-top: 0; }
+  .cm-recharge__layout {
+    display: grid;
+    grid-template-columns: 45fr 55fr;
+    grid-template-areas: "visuals panel";
+    gap: 3rem;
+    align-items: flex-start;
+    padding: 1.5rem 0;
+  }
+  .cm-recharge__visuals {
+    grid-area: visuals;
+    position: sticky;
+    top: 1.5rem;
+    align-self: flex-start;
+  }
+  .cm-recharge__panel {
+    grid-area: panel;
+    padding-top: 0;
+  }
 }
 
 @media (max-width: 1023px) {
+  .cm-recharge__layout { padding: 1.5rem 1.2rem; }
   .cm-recharge__media { order: -1; position: static; top: auto; }
   .cm-recharge__panel { padding-top: 0; }
 }


### PR DESCRIPTION
## Summary
- adjust the recharge layout container padding and grid areas to match the core product layout
- update media styling so the hero image, placeholder, and generic embeds mirror standard product framing
- keep mobile spacing consistent while ensuring sticky visuals don’t introduce extra scroll space

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cc08790724832fa178a497afb02139