### PR TITLE
Fix blog hero mobile centering

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -235,7 +235,7 @@ body.collection-menu-open {
 
 /* --- Featured Article Hero --- */
 .blog-hero {
-  display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  display: grid; grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
   gap: 3rem; align-items: center;
   background-color: #f8f9fa; border: 1px solid #dee2e6;
   border-radius: 24px; padding: clamp(2rem, 4vw, 3.5rem);


### PR DESCRIPTION
## Summary
- allow the blog hero grid columns to shrink to the full viewport width so the hero stays centered on small screens

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cd495c4fd0832fbfbf9e7b9b6ba098