### PR TITLE
Align CM recharge layout with sidebar shell

### DIFF
--- a/assets/cm-recharge.css
+++ b/assets/cm-recharge.css
@@ -15,6 +15,28 @@
   padding-right: 0 !important;
 }
 
+/* --- Structural Helpers --- */
+.cm-recharge {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+}
+
+.cm-recharge__inner {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 100%;
+}
+
+.cm-recharge__main {
+  flex: 1 0 auto;
+}
+
+.cm-recharge__footer {
+  margin-top: auto;
+}
+
 /* --- Main Layout --- */
 /* Final Width Fix: Remove horizontal constraints from the theme's .container class */
 .cm-recharge__main.container {

--- a/sections/product-cm-recharge.liquid
+++ b/sections/product-cm-recharge.liquid
@@ -12,7 +12,7 @@
 
 <div
   id="cm-recharge-root-{{ section.id }}"
-  class="cm-recharge product product-template"
+  class="cm-recharge product product-template full-viewport"
   data-section-id="{{ section.id }}"
   data-product-handle="{{ product.handle }}"
   data-bundle-product-id="{{ product.id }}"
@@ -22,8 +22,9 @@
   data-protein-collection-id="{{ protein_collection.id | default: '' }}"
   data-side-collection-id="{{ side_collection.id | default: '' }}"
 >
-  <div class="product-main cm-recharge__main container">
-    <div class="product-main__layout cm-recharge__layout">
+  <div class="cm-recharge__inner pad-safe-bottom">
+    <div class="product-main cm-recharge__main container">
+      <div class="product-main__layout cm-recharge__layout">
       {% liquid
         assign hero_media = product.selected_or_first_available_variant.featured_media | default: product.featured_media
         if hero_media == blank and product.media.size > 0
@@ -141,6 +142,11 @@
           <div class="cm-recharge__error" data-error-message></div>
         </form>
       </section>
+      </div>
+    </div>
+
+    <div class="cm-recharge__footer">
+      {% render 'footer-minimal-ordering' %}
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- wrap the Custom Meal Recharge section content in a flex column that mirrors the sidebar shell behaviour
- add the minimal ordering footer to the recharge product page for consistency
- introduce CSS helpers so the recharge layout fills the viewport and anchors the footer at the bottom

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd75af7b28832f9fae69f66556b5b0