### PR TITLE
Fix cm recharge footer spacing

### DIFF
--- a/assets/cm-recharge.css
+++ b/assets/cm-recharge.css
@@ -34,7 +34,25 @@
 }
 
 .cm-recharge__footer {
-  margin-top: auto;
+  margin-top: 2.5rem;
+}
+
+/* Remove the rigid viewport height from the shell layout so the footer hugs the content. */
+body.template-product.template-suffix--cm-recharge .collection-page__layout {
+  height: auto;
+  min-height: 0;
+}
+
+body.template-product.template-suffix--cm-recharge .collection-page__main {
+  height: auto;
+  min-height: 0;
+  overflow: visible;
+  padding-bottom: 0;
+}
+
+body.template-product.template-suffix--cm-recharge .cm-recharge,
+body.template-product.template-suffix--cm-recharge .cm-recharge__inner {
+  min-height: auto;
 }
 
 /* --- Main Layout --- */


### PR DESCRIPTION
## Summary
- prevent the collection shell from forcing a viewport-height layout on the cm recharge template
- allow the cm recharge footer to sit directly below the builder content with a consistent margin

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cd77c0ba14832f98d96af4f5867cbd