### PR TITLE
Fix subscription plan application for custom meal bundle

### DIFF
--- a/assets/cm-recharge.js
+++ b/assets/cm-recharge.js
@@ -441,11 +441,6 @@ class CustomMealBuilder {
       externalVariantId: String(variantDetails.variantId),
       quantity: 1,
     };
-    if (this.state.sellingPlanId) {
-      const sp = Number(this.state.sellingPlanId);
-      selection.sellingPlanId = sp;
-      selection.sellingPlan = sp;
-    }
     return selection;
   }
 
@@ -481,8 +476,17 @@ class CustomMealBuilder {
           items = items.map(line => {
             const vid = String(line.id ?? line.variant_id ?? line.variantId ?? '');
             if (vid === bundleVid) {
-              return { ...line, selling_plan: sp };
+              const withPlan = { ...line, selling_plan: sp };
+              console.debug('[CM Recharge] Applied selling plan to bundle parent', withPlan);
+              return withPlan;
             }
+
+            if ('selling_plan' in line) {
+              const cleaned = { ...line };
+              delete cleaned.selling_plan;
+              return cleaned;
+            }
+
             return line;
           });
         }


### PR DESCRIPTION
## Summary
- stop attaching selling plan identifiers to bundle component selections
- ensure the selling plan is only applied to the bundle parent line item and strip it from others
- add console debugging to confirm the selling plan is applied to the correct payload line

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cead05d604832f82f709809e2c593c