### PR TITLE
Ensure recharge product layout stays full height

### DIFF
--- a/assets/cm-recharge.css
+++ b/assets/cm-recharge.css
@@ -37,22 +37,42 @@
   margin-top: 2.5rem;
 }
 
-/* Remove the rigid viewport height from the shell layout so the footer hugs the content. */
+/* Restore the full-height shell while keeping the scrollable area confined to the main column. */
 body.template-product.template-suffix--cm-recharge .collection-page__layout {
-  height: auto;
-  min-height: 0;
+  height: calc(100dvh - var(--app-header-min-height) - var(--app-footer-min-height));
+  min-height: calc(100dvh - var(--app-header-min-height) - var(--app-footer-min-height));
+}
+
+@supports not (height: 100dvh) {
+  body.template-product.template-suffix--cm-recharge .collection-page__layout {
+    height: calc(100svh - var(--app-header-min-height) - var(--app-footer-min-height));
+    min-height: calc(100svh - var(--app-header-min-height) - var(--app-footer-min-height));
+  }
+}
+
+@supports not (height: 100svh) {
+  body.template-product.template-suffix--cm-recharge .collection-page__layout {
+    height: calc(100vh - var(--app-header-min-height) - var(--app-footer-min-height));
+    min-height: calc(100vh - var(--app-header-min-height) - var(--app-footer-min-height));
+  }
 }
 
 body.template-product.template-suffix--cm-recharge .collection-page__main {
-  height: auto;
-  min-height: 0;
-  overflow: visible;
-  padding-bottom: 0;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 100%;
+  overflow-y: auto;
+  padding-bottom: max(0.5rem, env(safe-area-inset-bottom));
+}
+
+body.template-product.template-suffix--cm-recharge .collection-page__sidebar {
+  height: 100%;
 }
 
 body.template-product.template-suffix--cm-recharge .cm-recharge,
 body.template-product.template-suffix--cm-recharge .cm-recharge__inner {
-  min-height: auto;
+  min-height: 100%;
 }
 
 /* --- Main Layout --- */


### PR DESCRIPTION
## Summary
- restore the recharge product layout to a fixed full-height grid so the sidebar stays flush with the viewport
- confine scrolling to the main content column while keeping the custom recharge section stretched to the viewport height

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ceb2b248e0832fbbba25d738dda772