### PR TITLE
Adjust cm recharge layout height handling

### DIFF
--- a/assets/cm-recharge.css
+++ b/assets/cm-recharge.css
@@ -19,14 +19,14 @@
 .cm-recharge {
   display: flex;
   flex-direction: column;
-  min-height: 100%;
+  min-height: 0;
 }
 
 .cm-recharge__inner {
   display: flex;
   flex-direction: column;
   flex: 1 1 auto;
-  min-height: 100%;
+  min-height: 0;
 }
 
 .cm-recharge__main {
@@ -39,20 +39,17 @@
 
 /* Restore the full-height shell while keeping the scrollable area confined to the main column. */
 body.template-product.template-suffix--cm-recharge .collection-page__layout {
-  height: calc(100dvh - var(--app-header-min-height) - var(--app-footer-min-height));
   min-height: calc(100dvh - var(--app-header-min-height) - var(--app-footer-min-height));
 }
 
 @supports not (height: 100dvh) {
   body.template-product.template-suffix--cm-recharge .collection-page__layout {
-    height: calc(100svh - var(--app-header-min-height) - var(--app-footer-min-height));
     min-height: calc(100svh - var(--app-header-min-height) - var(--app-footer-min-height));
   }
 }
 
 @supports not (height: 100svh) {
   body.template-product.template-suffix--cm-recharge .collection-page__layout {
-    height: calc(100vh - var(--app-header-min-height) - var(--app-footer-min-height));
     min-height: calc(100vh - var(--app-header-min-height) - var(--app-footer-min-height));
   }
 }
@@ -60,9 +57,9 @@ body.template-product.template-suffix--cm-recharge .collection-page__layout {
 body.template-product.template-suffix--cm-recharge .collection-page__main {
   display: flex;
   flex-direction: column;
-  height: 100%;
-  min-height: 100%;
-  overflow-y: auto;
+  height: auto;
+  min-height: 0;
+  overflow: visible;
   padding-bottom: max(0.5rem, env(safe-area-inset-bottom));
 }
 
@@ -72,7 +69,7 @@ body.template-product.template-suffix--cm-recharge .collection-page__sidebar {
 
 body.template-product.template-suffix--cm-recharge .cm-recharge,
 body.template-product.template-suffix--cm-recharge .cm-recharge__inner {
-  min-height: 100%;
+  min-height: 0;
 }
 
 /* --- Main Layout --- */


### PR DESCRIPTION
## Summary
- let the cm recharge wrapper and shell grow naturally by dropping forced 100% min-heights
- stop fixing the collection layout and main column to the viewport height so the page no longer accumulates blank space while interacting with the form
- keep the safe-area padding while allowing the main column to overflow normally

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ceb409a610832f94877f560fa02aa0