### PR TITLE
Align cm recharge product layout with sidebar shell

### DIFF
--- a/assets/cm-recharge.css
+++ b/assets/cm-recharge.css
@@ -37,20 +37,26 @@
   margin-top: 2.5rem;
 }
 
-body.template-product.template-suffix--cm-recharge .collection-page__main {
-  height: 100%;
-  overflow-y: auto;      /* match shell */
-  min-width: 0;
-  padding: 0 1.5rem  max(0.5rem, env(safe-area-inset-bottom)) 1.5rem;
+body.template-product.template-suffix--cm-recharge .collection-page__layout {
+  height: calc(100vh - var(--dynamic-header-h, var(--header-offset, 64px)));
+  overflow: hidden;
+  min-height: 0;
+  align-items: flex-start;
 }
 
-body.template-product.template-suffix--cm-recharge .collection-page__layout {
-  align-items: flex-start;
+body.template-product.template-suffix--cm-recharge .collection-page__main {
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  min-width: 0;
+  height: 100%;
+  padding: 0 1.5rem;
+  padding-bottom: max(0.5rem, env(safe-area-inset-bottom, 0));
 }
 
 body.template-product.template-suffix--cm-recharge .collection-page__sidebar {
   height: 100%;
-  overflow: hidden;      /* inner cart scrolls */
+  overflow: hidden;
   align-self: stretch;
 }
 
@@ -59,18 +65,53 @@ body.template-product.template-suffix--cm-recharge .cart-sidebar {
   height: 100%;
   display: flex;
   flex-direction: column;
+  min-height: 0;
 }
 
 body.template-product.template-suffix--cm-recharge .cart-sidebar__content,
-body.template-product.template-suffix--cm-recharge .cart {
+body.template-product.template-suffix--cm-recharge .cart,
+body.template-product.template-suffix--cm-recharge .cart-drawer__content {
   height: 100%;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
 }
 
+body.template-product.template-suffix--cm-recharge .cart-empty-box {
+  min-height: 0 !important;
+}
+
 body.template-product.template-suffix--cm-recharge .cm-recharge,
-body.template-product.template-suffix--cm-recharge .cm-recharge__inner {
-  min-height: 0;
+body.template-product.template-suffix--cm-recharge .cm-recharge__inner,
+body.template-product.template-suffix--cm-recharge .cm-recharge__footer {
+  min-height: 0 !important;
+  height: auto !important;
+  overflow: visible !important;
+}
+
+@media (max-width: 991px) {
+  body.template-product.template-suffix--cm-recharge .collection-page__layout {
+    height: auto;
+    overflow: visible;
+  }
+
+  body.template-product.template-suffix--cm-recharge .collection-page__main {
+    overflow: visible;
+    height: auto;
+  }
+
+  body.template-product.template-suffix--cm-recharge .collection-page__sidebar {
+    height: auto;
+    overflow: visible;
+  }
+
+  body.template-product.template-suffix--cm-recharge .cart-sidebar-section-wrapper,
+  body.template-product.template-suffix--cm-recharge .cart-sidebar,
+  body.template-product.template-suffix--cm-recharge .cart-sidebar__content,
+  body.template-product.template-suffix--cm-recharge .cart,
+  body.template-product.template-suffix--cm-recharge .cart-drawer__content {
+    height: auto;
+    overflow: visible;
+  }
 }
 
 /* --- Main Layout --- */

--- a/sections/product-cm-recharge.liquid
+++ b/sections/product-cm-recharge.liquid
@@ -172,6 +172,36 @@
   })();
 </script>
 
+<script>
+  (function() {
+    const setHeaderOffsets = function() {
+      const header = document.querySelector('#shopify-section-header-collections') || document.querySelector('#shopify-section-header');
+      if (!header) {
+        return;
+      }
+      var height = header.getBoundingClientRect().height;
+      document.documentElement.style.setProperty('--header-offset', height + 'px');
+      document.documentElement.style.setProperty('--dynamic-header-h', height + 'px');
+    };
+
+    const registerListeners = function() {
+      if (!window.__cmRechargeHeaderOffsetListenersRegistered) {
+        window.__cmRechargeHeaderOffsetListenersRegistered = true;
+        window.addEventListener('resize', setHeaderOffsets);
+        document.addEventListener('shopify:section:load', setHeaderOffsets);
+        document.addEventListener('shopify:section:reorder', setHeaderOffsets);
+      }
+      setHeaderOffsets();
+    };
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', registerListeners);
+    } else {
+      registerListeners();
+    }
+  })();
+</script>
+
 <link rel="stylesheet" href="{{ 'cm-recharge.css' | asset_url }}">
 <script src="{{ 'cm-recharge.js' | asset_url }}" defer="defer"></script>
 

--- a/snippets/cart-preview-sidebar.liquid
+++ b/snippets/cart-preview-sidebar.liquid
@@ -152,37 +152,39 @@
     <div class="cart-sidebar__header">
       <h2 class="cart-sidebar__title">{{ 'cart.general.title' | t }}</h2>
     </div>
-    {%- if cart.item_count > 0 -%}
-      <div class="cart-progress cart-progress--green">
-        <p class="cart-progress__text" aria-live="polite">{{ progress_message | strip }}</p>
-        <div class="cart-progress__bar" role="progressbar" aria-label="Meal progress toward order minimum" aria-valuenow="{{ progress_current }}" aria-valuemin="0" aria-valuemax="{{ progress_target }}" aria-valuetext="{{ progress_current }} of {{ progress_target }} meals">
-          <div class="cart-progress__bar-inner" style="width: {{ progress_percentage }}%;"></div>
+    <div class="cart-sidebar__content">
+      {%- if cart.item_count > 0 -%}
+        <div class="cart-progress cart-progress--green">
+          <p class="cart-progress__text" aria-live="polite">{{ progress_message | strip }}</p>
+          <div class="cart-progress__bar" role="progressbar" aria-label="Meal progress toward order minimum" aria-valuenow="{{ progress_current }}" aria-valuemin="0" aria-valuemax="{{ progress_target }}" aria-valuetext="{{ progress_current }} of {{ progress_target }} meals">
+            <div class="cart-progress__bar-inner" style="width: {{ progress_percentage }}%;"></div>
+          </div>
         </div>
-      </div>
-    {%- endif -%}
-    
-    {% render 'cart-item-list', context: 'sidebar' %}
+      {%- endif -%}
 
-    {% if cart.item_count > 0 %}
-      <div class="cart-sidebar__footer">
-                  <div class="cart-sidebar__summary">
+      {% render 'cart-item-list', context: 'sidebar' %}
+
+      {% if cart.item_count > 0 %}
+        <div class="cart-sidebar__footer">
+          <div class="cart-sidebar__summary">
             <span class="cart-sidebar__summary-label">{{ 'cart.general.subtotal' | t }}</span>
             <span class="cart-sidebar__summary-value">
               {%- if cart.total_discount > 0 -%}<del class="money">{{ cart.original_total_price | money }}</del>{%- endif -%}
               <span class="money"><span style="display:none" class="tdf-cart-total-flag"></span>{{ cart.total_price | money }}</span>
             </span>
           </div>
-        <p class="cart-drawer__subtext">{{ 'cart.general.taxes_and_shipping_at_checkout' | t }}</p>
-        <div class="cart-sidebar__actions">
-           <a href="{{ checkout_url }}" class="btn cart-sidebar__checkout-btn">
-            Proceed to Checkout
-          </a>
+          <p class="cart-drawer__subtext">{{ 'cart.general.taxes_and_shipping_at_checkout' | t }}</p>
+          <div class="cart-sidebar__actions">
+             <a href="{{ checkout_url }}" class="btn cart-sidebar__checkout-btn">
+              Proceed to Checkout
+            </a>
+          </div>
+          <div class="cart-drawer__continue-action">
+            <a href="{{ routes.cart_url }}" class="cart-drawer__secondary-link">View Full Cart</a>
+          </div>
         </div>
-        <div class="cart-drawer__continue-action">
-          <a href="{{ routes.cart_url }}" class="cart-drawer__secondary-link">View Full Cart</a>
-        </div>
-      </div>
-    {% endif %}
+      {% endif %}
+    </div>
     <div class="cart-sidebar__loader-overlay">
       <div class="cart-sidebar__spinner"></div>
     </div>


### PR DESCRIPTION
## Summary
- constrain the cm-recharge product shell to the viewport and split scrolling between the main and sidebar columns
- ensure the cart sidebar uses an internal scroll wrapper to keep the column fixed height
- compute and update the dynamic header offset variables for the cm-recharge template to respect header height

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf0fa0d0ac832f8382402586d8a226