### PR TITLE
Restore Recharge product shell layout

### DIFF
--- a/assets/cm-recharge.css
+++ b/assets/cm-recharge.css
@@ -37,87 +37,6 @@
   margin-top: 2.5rem;
 }
 
-body.template-product.template-suffix--cm-recharge .collection-page__layout {
-  height: calc(100vh - var(--dynamic-header-h, var(--header-offset, 64px)));
-  overflow: hidden;
-  min-height: 0;
-  align-items: flex-start;
-}
-
-body.template-product.template-suffix--cm-recharge .collection-page__main {
-  display: flex;
-  flex-direction: column;
-  overflow-y: auto;
-  min-width: 0;
-  height: 100%;
-  padding: 0 1.5rem;
-  padding-bottom: max(0.5rem, env(safe-area-inset-bottom, 0));
-}
-
-body.template-product.template-suffix--cm-recharge .collection-page__sidebar {
-  height: 100%;
-  overflow: hidden;
-  align-self: stretch;
-}
-
-body.template-product.template-suffix--cm-recharge .cart-sidebar-section-wrapper,
-body.template-product.template-suffix--cm-recharge .cart-sidebar {
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-}
-
-body.template-product.template-suffix--cm-recharge .cart-sidebar__content {
-  flex: 1 1 auto;             /* fill remaining space under the header */
-  min-height: 0;              /* critical: prevent overflow calc bug */
-  overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
-}
-
-/* keep header/footer static within the column */
-body.template-product.template-suffix--cm-recharge .cart-sidebar__header,
-body.template-product.template-suffix--cm-recharge .cart-sidebar__footer {
-  flex: 0 0 auto;
-}
-
-body.template-product.template-suffix--cm-recharge .cart-empty-box {
-  min-height: 0 !important;
-}
-
-body.template-product.template-suffix--cm-recharge .cm-recharge,
-body.template-product.template-suffix--cm-recharge .cm-recharge__inner,
-body.template-product.template-suffix--cm-recharge .cm-recharge__footer {
-  min-height: 0 !important;
-  height: auto !important;
-  overflow: visible !important;
-}
-
-@media (max-width: 991px) {
-  body.template-product.template-suffix--cm-recharge .collection-page__layout {
-    height: auto;
-    overflow: visible;
-  }
-
-  body.template-product.template-suffix--cm-recharge .collection-page__main {
-    overflow: visible;
-    height: auto;
-  }
-
-  body.template-product.template-suffix--cm-recharge .collection-page__sidebar {
-    height: auto;
-    overflow: visible;
-  }
-
-  body.template-product.template-suffix--cm-recharge .cart-sidebar-section-wrapper,
-  body.template-product.template-suffix--cm-recharge .cart-sidebar,
-  body.template-product.template-suffix--cm-recharge .cart-sidebar__content,
-  body.template-product.template-suffix--cm-recharge .cart,
-  body.template-product.template-suffix--cm-recharge .cart-drawer__content {
-    height: auto;
-    overflow: visible;
-  }
-}
-
 /* --- Main Layout --- */
 /* Final Width Fix: Remove horizontal constraints from the theme's .container class */
 .cm-recharge__main.container {
@@ -332,7 +251,7 @@ body.template-product.template-suffix--cm-recharge .cm-recharge__footer {
 /* --- Responsive Overrides --- */
 @media (min-width: 1024px) {
   /* Safety: keep the exact 45/55 split used on the legacy PDP */
-  .product-main__layout.cm-recharge__layout {
+  .cm-recharge__layout {
     display: grid;
     grid-template-columns: 45fr 55fr !important;
     grid-template-areas: "visuals panel";

--- a/layout/product-shell.liquid
+++ b/layout/product-shell.liquid
@@ -313,7 +313,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
                               </div>
                               <aside class="collection-page__sidebar">
-                                {% render 'cart-preview-sidebar' %}
+                                {% section 'cart-sidebar' %}
                               </aside>
                             </div>
                           </div>

--- a/sections/product-cm-recharge.liquid
+++ b/sections/product-cm-recharge.liquid
@@ -23,8 +23,8 @@
   data-side-collection-id="{{ side_collection.id | default: '' }}"
 >
   <div class="cm-recharge__inner pad-safe-bottom">
-    <div class="product-main cm-recharge__main container">
-      <div class="product-main__layout cm-recharge__layout">
+    <div class="cm-recharge__main container">
+      <div class="cm-recharge__layout">
       {% liquid
         assign hero_media = product.selected_or_first_available_variant.featured_media | default: product.featured_media
         if hero_media == blank and product.media.size > 0
@@ -33,9 +33,9 @@
       %}
 
       <!-- Wrapper for Left Column Content -->
-      <div class="product-main__visuals-wrapper cm-recharge__visuals">
+      <div class="cm-recharge__visuals">
         <!-- LEFT: Media / Hero Image -->
-        <section class="product-main__gallery cm-recharge__media card card--soft">
+        <section class="cm-recharge__media card card--soft">
           {% if hero_media %}
             {% assign hero_alt = hero_media.alt | default: product.title %}
             <div class="cm-recharge__media-frame">
@@ -61,7 +61,7 @@
 
 
       <!-- RIGHT: Builder Panel -->
-      <section class="product-main__info-column cm-recharge__panel">
+      <section class="cm-recharge__panel">
         <div class="cm-recharge__intro">
           <h1 class="cm-recharge__title h2">{{ product.title | escape }}</h1>
           <div class="product-price--placeholder">


### PR DESCRIPTION
## Summary
- ensure the Recharge product shell renders the standard two-column app layout with the cart sidebar section
- simplify the Custom Meal Builder section markup so it only outputs the builder UI within the shared shell
- drop conflicting layout overrides from the Recharge stylesheet to rely on global collection layout styling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cff2cae0d4832fb7cfb30f4a943dc0