### PR TITLE
Fix custom meal unit detection and cart properties

### DIFF
--- a/assets/cm-recharge.css
+++ b/assets/cm-recharge.css
@@ -180,8 +180,23 @@
   font-weight: 600; box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
 .variant-option-button::after {
-  content: 'oz'; margin-left: 4px; font-weight: 400; font-size: 0.8em;
-  color: inherit; opacity: 0.9;
+  content: attr(data-unit);
+  margin-left: 4px;
+  font-weight: 400;
+  font-size: 0.8em;
+  color: inherit;
+  opacity: 0.9;
+}
+
+.variant-option-button:not([data-unit]),
+.variant-option-button[data-unit=""] {
+  --has-unit: 0;
+}
+
+.variant-option-button:not([data-unit])::after,
+.variant-option-button[data-unit=""]::after {
+  content: '';
+  margin-left: 0;
 }
 
 /* --- Utilities & Original Elements --- */


### PR DESCRIPTION
## Summary
- parse unit metadata for custom meal variants so the builder can show the correct measurement per option
- expose the detected unit on the option buttons instead of hard-coding ounces in CSS
- enrich parent bundle line item properties so cart surfaces receive ingredient names and measured quantities

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68cffdadfbd4832fabdd2986673b8ebe