### PR TITLE
Adjust cm recharge visuals sticky offset

### DIFF
--- a/assets/cm-recharge.css
+++ b/assets/cm-recharge.css
@@ -80,7 +80,7 @@
   .cm-recharge__visuals {
     grid-area: visuals;
     position: sticky;
-    top: 1.5rem;
+    top: calc(var(--header-offset, 0px) + 1.5rem);
   }
   .cm-recharge__panel {
     grid-area: panel;


### PR DESCRIPTION
## Summary
- offset the sticky cm-recharge visuals container by the dynamic header height to prevent overlap with the collection header

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d41eec3844832f95fbede4a8235259