### PR TITLE
Restore one-time cadence option and polish layout

### DIFF
--- a/assets/cm-recharge.css
+++ b/assets/cm-recharge.css
@@ -153,12 +153,6 @@
 }
 .cm-recharge__badge-icon { font-size: 1rem; line-height: 1; }
 .cm-recharge__badge-text { white-space: normal; }
-.cm-recharge__nutrition-heading {
-  font-size: 1rem;
-  font-weight: 700;
-  color: #1f2933;
-  margin-bottom: 0.75rem;
-}
 .cm-recharge__nutrition-shell .nutrition-container-v8 { margin-top: 0; }
 .cm-recharge__nutrition-shell .nutrition-panel-v8 {
   background: #ffffff;
@@ -171,7 +165,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
-  padding: 1.25rem;
+  padding: 0;
 }
 .cm-recharge__nutrition-shell .macro-stat {
   flex: 1 1 calc(33% - 0.5rem);
@@ -260,6 +254,13 @@
   clip: rect(0 0 0 0);
   clip-path: inset(50%);
   pointer-events: none;
+}
+
+@media (max-width: 63.9375rem) {
+  .cm-recharge__cta-block { order: 2; }
+  .cm-cadence { order: 3; }
+  .cm-recharge__badges { order: 4; }
+  .cm-recharge__nutrition-shell--mobile { order: 5; margin-top: 1.25rem; }
 }
 .cm-recharge__cta-block {
   display: flex;

--- a/sections/product-cm-recharge.liquid
+++ b/sections/product-cm-recharge.liquid
@@ -55,7 +55,6 @@
             {% endif %}
           </section>
           <div class="cm-recharge__nutrition-shell" data-desktop-nutrition-slot>
-            <div class="cm-recharge__nutrition-heading" aria-hidden="true">Performance-focused nutrition you can count on.</div>
             <div
               id="nutrition-container-v2"
               class="cm-recharge-macro-container nutrition-container-v8"
@@ -104,16 +103,22 @@
               <div class="cm-recharge__badge"><span class="cm-recharge__badge-icon" role="img" aria-label="Fresh, never frozen">❄️</span><span class="cm-recharge__badge-text">Fresh, Never Frozen</span></div>
             </div>
 
-            <div class="cm-recharge__nutrition-shell cm-recharge__nutrition-shell--mobile" data-mobile-nutrition-slot>
-              <div class="cm-recharge__nutrition-heading" aria-hidden="true">Performance-focused nutrition you can count on.</div>
-            </div>
+            <div class="cm-recharge__nutrition-shell cm-recharge__nutrition-shell--mobile" data-mobile-nutrition-slot></div>
 
             <div class="cm-cadence" data-cadence-block>
               <div class="cm-cadence__header">
                 <p class="cm-cadence__title">Delivery cadence</p>
-                <p class="cm-cadence__note" data-cadence-note>Default is weekly. You can change cadence anytime.</p>
+                <p
+                  class="cm-cadence__note"
+                  data-cadence-note
+                  data-default-note="Default is weekly. You can change cadence anytime."
+                  data-one-time-note="One-time purchase selected. Subscribe anytime for recurring deliveries."
+                >
+                  Default is weekly. You can change cadence anytime.
+                </p>
               </div>
               <div class="cm-cadence__pills" data-cadence-pills>
+                <button type="button" class="cm-cadence__pill" data-cadence-option="one-time">One-Time</button>
                 <button type="button" class="cm-cadence__pill" data-cadence-option="weekly">Weekly</button>
                 <button type="button" class="cm-cadence__pill" data-cadence-option="biweekly">Every 2 Weeks</button>
               </div>
@@ -186,10 +191,13 @@
       var pills = root.querySelector('[data-cadence-pills]');
       if (!frequencySelect || !pills || frequencySelect.dataset.cadenceInitialized === 'true') return;
 
+      var oneTimeButton = pills.querySelector('[data-cadence-option="one-time"]');
       var weeklyButton = pills.querySelector('[data-cadence-option="weekly"]');
       var biweeklyButton = pills.querySelector('[data-cadence-option="biweekly"]');
       var cadenceNote = root.querySelector('[data-cadence-note]');
       var cadenceBlock = root.querySelector('[data-cadence-block]');
+      var cadenceNoteDefault = cadenceNote ? (cadenceNote.dataset.defaultNote || cadenceNote.textContent) : '';
+      var cadenceNoteOneTime = cadenceNote ? (cadenceNote.dataset.oneTimeNote || '') : '';
 
       function findOptionByWeeks(weeks) {
         var options = Array.prototype.slice.call(frequencySelect.options || []);
@@ -200,11 +208,24 @@
         }) || null;
       }
 
-      function setActiveButton(button) {
+      function setActiveButton(button, mode) {
         Array.prototype.forEach.call(pills.querySelectorAll('.cm-cadence__pill'), function(el) {
           el.classList.toggle('is-active', el === button);
           el.setAttribute('aria-pressed', el === button ? 'true' : 'false');
         });
+
+        if (!cadenceNote) return;
+
+        if (mode === 'one-time') {
+          cadenceNote.textContent = cadenceNoteOneTime || cadenceNoteDefault;
+          cadenceNote.classList.remove('is-muted');
+        } else if (mode === 'weekly' || mode === 'biweekly') {
+          cadenceNote.textContent = cadenceNoteDefault;
+          cadenceNote.classList.remove('is-muted');
+        } else {
+          cadenceNote.textContent = cadenceNoteDefault;
+          cadenceNote.classList.remove('is-muted');
+        }
       }
 
       function syncFromSelect() {
@@ -213,16 +234,18 @@
           setActiveButton(null);
           return;
         }
-        if (weeklyOption && selectedOption.value === weeklyOption.value) {
-          setActiveButton(weeklyButton);
+        if (selectedOption.value === '' && oneTimeButton) {
+          setActiveButton(oneTimeButton, 'one-time');
+        } else if (weeklyOption && selectedOption.value === weeklyOption.value) {
+          setActiveButton(weeklyButton, 'weekly');
         } else if (biweeklyOption && selectedOption.value === biweeklyOption.value) {
-          setActiveButton(biweeklyButton);
+          setActiveButton(biweeklyButton, 'biweekly');
         } else {
           setActiveButton(null);
         }
       }
 
-      function attachButton(button, option) {
+      function attachButton(button, option, mode) {
         if (!button) return;
         if (!option) {
           button.setAttribute('hidden', 'hidden');
@@ -232,7 +255,16 @@
         button.addEventListener('click', function() {
           if (frequencySelect.disabled) return;
           dispatchNativeChange(frequencySelect, option.value);
-          setActiveButton(button);
+          setActiveButton(button, mode);
+        });
+      }
+
+      function attachOneTimeButton(button) {
+        if (!button) return;
+        button.addEventListener('click', function() {
+          if (frequencySelect.disabled) return;
+          dispatchNativeChange(frequencySelect, '');
+          setActiveButton(button, 'one-time');
         });
       }
 
@@ -242,23 +274,29 @@
         weeklyOption = findOptionByWeeks(1);
         biweeklyOption = findOptionByWeeks(2);
 
+        attachOneTimeButton(oneTimeButton);
+        attachButton(weeklyButton, weeklyOption, 'weekly');
+        attachButton(biweeklyButton, biweeklyOption, 'biweekly');
+
         if (!weeklyOption && !biweeklyOption) {
-          pills.classList.add('is-hidden');
-          if (cadenceNote) cadenceNote.classList.add('is-muted');
-          if (cadenceBlock) cadenceBlock.classList.add('is-hidden');
-          return;
-        }
-
-        attachButton(weeklyButton, weeklyOption);
-        attachButton(biweeklyButton, biweeklyOption);
-
-        if (weeklyOption) {
-          var shouldDefaultToWeekly = !frequencySelect.value || frequencySelect.selectedIndex === 0;
-          if (shouldDefaultToWeekly || frequencySelect.value !== weeklyOption.value) {
-            dispatchNativeChange(frequencySelect, weeklyOption.value);
+          if (oneTimeButton) {
+            setActiveButton(oneTimeButton, 'one-time');
+            dispatchNativeChange(frequencySelect, '');
+          } else {
+            pills.classList.add('is-hidden');
+            if (cadenceNote) cadenceNote.classList.add('is-muted');
+            if (cadenceBlock) cadenceBlock.classList.add('is-hidden');
+            return;
           }
-        } else if (biweeklyOption && (!frequencySelect.value || frequencySelect.selectedIndex === 0)) {
-          dispatchNativeChange(frequencySelect, biweeklyOption.value);
+        } else {
+          if (weeklyOption) {
+            var shouldDefaultToWeekly = !frequencySelect.value || frequencySelect.selectedIndex === 0;
+            if (shouldDefaultToWeekly || frequencySelect.value !== weeklyOption.value) {
+              dispatchNativeChange(frequencySelect, weeklyOption.value);
+            }
+          } else if (biweeklyOption && (!frequencySelect.value || frequencySelect.selectedIndex === 0)) {
+            dispatchNativeChange(frequencySelect, biweeklyOption.value);
+          }
         }
 
         syncFromSelect();


### PR DESCRIPTION
## Summary
- restore the one-time purchase pill within the cadence selector and adjust helper messaging for each state
- remove the added nutrition heading and excess macro grid padding introduced by the previous iteration
- reprioritize the mobile layout so the CTA appears earlier and supporting badges/nutrition content follow without disrupting ordering flow

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d5619ab588832fad17977d61659256