### PR TITLE
Restore cart custom meal list styling on Recharge PDP

### DIFF
--- a/assets/cm-recharge.css
+++ b/assets/cm-recharge.css
@@ -329,4 +329,43 @@ body.template-product.template-suffix--cm-recharge .cart-sidebar,
 body.template-product.template-suffix--cm-recharge .cart-sidebar__content { display: flex; flex-direction: column; }
 body.template-product.template-suffix--cm-recharge .cart-sidebar__content { flex: 1 1 auto; }
 body.template-product.template-suffix--cm-recharge .cart-sidebar__footer { margin-top: auto; }
+/* Cart bundle ingredient list reset (keeps cart styling when cm-recharge.css loads after custom.css) */
+body.template-product.template-suffix--cm-recharge .cart-sidebar__properties--custom,
+body.template-product.template-suffix--cm-recharge .cart-drawer__properties--custom {
+  margin: 0.375rem 0 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+body.template-product.template-suffix--cm-recharge .cart-sidebar__property,
+body.template-product.template-suffix--cm-recharge .cart-drawer__property {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.3;
+}
+
+body.template-product.template-suffix--cm-recharge .cart-sidebar__property-value.ingredient-line,
+body.template-product.template-suffix--cm-recharge .cart-drawer__property-value.ingredient-line {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.375rem;
+  line-height: 1.3;
+}
+
+body.template-product.template-suffix--cm-recharge .ingredient-qty {
+  font-size: 0.875rem;
+  font-weight: 400;
+  color: #121212;
+  text-transform: none;
+}
+
+body.template-product.template-suffix--cm-recharge .ingredient-name {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #121212;
+  text-transform: none;
+}
 /* --- END: DEFINITIVE FULL-HEIGHT LAYOUT & SCROLL FIX --- */


### PR DESCRIPTION
## Summary
- re-apply the custom meal ingredient list spacing and typography rules when cm-recharge.css loads after custom.css on the Recharge PDP
- ensure bundle property lists keep the compact flex column layout so font sizing and spacing match the rest of the cart experiences

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d5895ed794832fa6b21f14a6160e37