### PR TITLE
Align cm recharge cart property styling

### DIFF
--- a/assets/cm-recharge.css
+++ b/assets/cm-recharge.css
@@ -329,11 +329,16 @@ body.template-product.template-suffix--cm-recharge .cart-sidebar,
 body.template-product.template-suffix--cm-recharge .cart-sidebar__content { display: flex; flex-direction: column; }
 body.template-product.template-suffix--cm-recharge .cart-sidebar__content { flex: 1 1 auto; }
 body.template-product.template-suffix--cm-recharge .cart-sidebar__footer { margin-top: auto; }
-/* Cart bundle ingredient list reset (keeps cart styling when cm-recharge.css loads after custom.css) */
+/* Cart bundle ingredient list alignment (mirror cart styling from custom.css for the new builder components) */
+body.template-product.template-suffix--cm-recharge .cart-sidebar__properties,
+body.template-product.template-suffix--cm-recharge .cart-drawer__properties {
+  align-items: flex-start;
+}
+
 body.template-product.template-suffix--cm-recharge .cart-sidebar__properties--custom,
 body.template-product.template-suffix--cm-recharge .cart-drawer__properties--custom {
-  margin: 0.375rem 0 0;
-  padding: 0;
+  margin: 0.5rem 0 0;
+  padding-left: 0;
   list-style: none;
   display: flex;
   flex-direction: column;
@@ -342,17 +347,35 @@ body.template-product.template-suffix--cm-recharge .cart-drawer__properties--cus
 
 body.template-product.template-suffix--cm-recharge .cart-sidebar__property,
 body.template-product.template-suffix--cm-recharge .cart-drawer__property {
-  margin: 0;
   font-size: 0.875rem;
   line-height: 1.3;
+  margin: 0 0 5px;
+  color: #495057;
+}
+
+body.template-product.template-suffix--cm-recharge .cart-sidebar__property:last-child,
+body.template-product.template-suffix--cm-recharge .cart-drawer__property:last-child {
+  margin-bottom: 0;
+}
+
+body.template-product.template-suffix--cm-recharge .cart-sidebar__property-name,
+body.template-product.template-suffix--cm-recharge .cart-drawer__property-name {
+  font-weight: 600;
+  color: #212529;
+}
+
+body.template-product.template-suffix--cm-recharge .cart-sidebar__property-value,
+body.template-product.template-suffix--cm-recharge .cart-drawer__property-value {
+  color: #495057;
 }
 
 body.template-product.template-suffix--cm-recharge .cart-sidebar__property-value.ingredient-line,
 body.template-product.template-suffix--cm-recharge .cart-drawer__property-value.ingredient-line {
-  display: inline-flex;
+  display: flex;
   align-items: baseline;
   gap: 0.375rem;
-  line-height: 1.3;
+  line-height: 1.35;
+  flex-wrap: wrap;
 }
 
 body.template-product.template-suffix--cm-recharge .ingredient-qty {
@@ -360,6 +383,7 @@ body.template-product.template-suffix--cm-recharge .ingredient-qty {
   font-weight: 400;
   color: #121212;
   text-transform: none;
+  margin-right: 0.5em;
 }
 
 body.template-product.template-suffix--cm-recharge .ingredient-name {


### PR DESCRIPTION
## Summary
- realign the cm-recharge cart property list styling with the global custom.css look
- restore spacing, typography, and alignment rules for ingredient lines in the builder cart sidebar
- ensure the custom meal builder cart uses the same property name/value presentation as other pages

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d58e64897c832fb0777feee81bbeb4