### PR TITLE
Fix collection layout height calculation

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -123,14 +123,14 @@ body.collection-menu-open {
   display: grid;
   grid-template-columns: 1fr 380px;
   height: calc(
-    100dvh - var(--app-header-min-height) - var(--collection-funnel-header-height, 0px) - var(--app-footer-min-height)
+    100dvh - var(--app-header-min-height) - var(--app-footer-min-height)
   );
 }
 
 @supports not (height: 100dvh) {
   .collection-page__layout {
     height: calc(
-      100svh - var(--app-header-min-height) - var(--collection-funnel-header-height, 0px) - var(--app-footer-min-height)
+      100svh - var(--app-header-min-height) - var(--app-footer-min-height)
     );
   }
 }
@@ -138,7 +138,7 @@ body.collection-menu-open {
 @supports not (height: 100svh) {
   .collection-page__layout {
     height: calc(
-      100vh - var(--app-header-min-height) - var(--collection-funnel-header-height, 0px) - var(--app-footer-min-height)
+      100vh - var(--app-header-min-height) - var(--app-footer-min-height)
     );
   }
 }
@@ -508,14 +508,14 @@ body.template-suffix--meal-plans .collection-page__main { padding-left: 0; paddi
 body.template-suffix--meal-plans .collection-header { padding-left: 1rem; padding-right: 1rem; margin: 0; }
 body[class*="template-suffix--meal-plans"] .collection-page__layout {
   height: calc(
-    100dvh - var(--app-header-min-height) - var(--collection-funnel-header-height, 0px) - var(--app-footer-min-height)
+    100dvh - var(--app-header-min-height) - var(--app-footer-min-height)
   );
 }
 
 @supports not (height: 100dvh) {
   body[class*="template-suffix--meal-plans"] .collection-page__layout {
     height: calc(
-      100svh - var(--app-header-min-height) - var(--collection-funnel-header-height, 0px) - var(--app-footer-min-height)
+      100svh - var(--app-header-min-height) - var(--app-footer-min-height)
     );
   }
 }
@@ -523,7 +523,7 @@ body[class*="template-suffix--meal-plans"] .collection-page__layout {
 @supports not (height: 100svh) {
   body[class*="template-suffix--meal-plans"] .collection-page__layout {
     height: calc(
-      100vh - var(--app-header-min-height) - var(--collection-funnel-header-height, 0px) - var(--app-footer-min-height)
+      100vh - var(--app-header-min-height) - var(--app-footer-min-height)
     );
   }
 }


### PR DESCRIPTION
## Summary
- stop subtracting the funnel header height from the collection page layout height so the grid fills the viewport without a trailing gap
- mirror the corrected height calculation for meal plan collection templates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d59aa089bc832faec3a56ed95469d6