### PR TITLE
Fix cart drawer ingredient truncation

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -1110,7 +1110,7 @@ body.template-suffix--meal-plans .collection-selector__toggle {
   display: inline-flex !important;
   align-items: baseline !important;
   gap: 0.35rem !important;
-  flex-wrap: wrap;
+  flex-wrap: nowrap !important;
 }
 
 /* Style the quantity part of the ingredient line */
@@ -1124,6 +1124,7 @@ body.template-suffix--meal-plans .collection-selector__toggle {
   text-transform: none !important;
   font-size: 0.875rem !important;
   font-variant-numeric: tabular-nums;
+  flex: 0 0 auto;
 }
 
 /* Style the name part of the ingredient line */
@@ -1132,6 +1133,11 @@ body.template-suffix--meal-plans .collection-selector__toggle {
   color: #121212 !important;
   text-transform: none !important;
   font-size: 0.875rem !important;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .cart-page__subscription-info,


### PR DESCRIPTION
## Summary
- prevent ingredient lines in the cart drawer from wrapping to multiple rows
- add ellipsis truncation for long ingredient names so quantity and name stay aligned

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5b0844244832fa9d7774106cb8c66