### PR TITLE
Restore legacy dynamic pricing behavior

### DIFF
--- a/assets/bold-combined-price.js
+++ b/assets/bold-combined-price.js
@@ -18,6 +18,8 @@
  * =================================================================================================================
  */
 document.addEventListener('DOMContentLoaded', () => {
+  // Skip on legacy templates that use their own section-scoped pricing.
+  if (document.querySelector('.product-main__price[data-legacy-pricing="true"]')) return;
   // --- 1. Element Selection ---
   // Support both the modern product-main layout and the legacy custom-meals template.
   const priceDisplayElement =

--- a/assets/legacy-dynamic-price.js
+++ b/assets/legacy-dynamic-price.js
@@ -1,0 +1,87 @@
+(() => {
+  document.addEventListener('DOMContentLoaded', () => {
+    const priceBlock = document.querySelector('.product-main__price[data-legacy-pricing="true"]');
+    if (!priceBlock) return;
+
+    const sectionEl    = priceBlock.closest('.product-main');
+    const priceDisplay = priceBlock.querySelector('[data-product-price]');
+    const qtyInput     = sectionEl?.querySelector('.integrated-quantity__input[name="quantity"]');
+    const qtyContainer = sectionEl?.querySelector('.integrated-quantity');
+    const formEl       = sectionEl?.querySelector('.product-main__form');
+
+    if (!sectionEl || !priceDisplay || !qtyInput || !qtyContainer || !formEl) return;
+
+    const moneyFormat = (window.Shopify && window.Shopify.money_format) || '';
+    const basePriceCents = Number(priceDisplay.getAttribute('data-base-price')) || 0;
+
+    let wentLive = false;
+    const goLive = () => {
+      if (wentLive) return;
+      priceBlock.classList.remove('price--placeholder');
+      priceBlock.classList.add('price--live');
+      priceDisplay.className = '';
+      wentLive = true;
+    };
+
+    const parseMoneyToCents = (t) => {
+      if (typeof t !== 'string') return 0;
+      const clean = t.replace(/[^0-9.]/g, '');
+      const n = parseFloat(clean);
+      return Number.isFinite(n) ? Math.round(n * 100) : 0;
+    };
+
+    const formatMoney = (cents) => {
+      const amt = (cents / 100).toFixed(2);
+      if (!moneyFormat) return `$${amt}`;
+      return moneyFormat.replace(/\{\{\s*amount\s*\}\}/, amt).replace('.00', '');
+    };
+
+    let boldTotalEl = formEl.querySelector('.bold_option_total');
+
+    const update = () => {
+      const extrasText = boldTotalEl?.querySelector('span')?.textContent || '0';
+      const extras = parseMoneyToCents(extrasText);
+      const qty = parseInt(qtyInput.value, 10) || 1;
+      const total = (basePriceCents + extras) * qty;
+      goLive();
+      priceDisplay.innerHTML = `${formatMoney(total)}<span class="price-note">updates as you choose</span>`;
+    };
+
+    const wireBold = () => {
+      if (!boldTotalEl || boldTotalEl.__wired) return;
+      boldTotalEl.__wired = true;
+
+      new MutationObserver(update).observe(boldTotalEl, {
+        childList: true,
+        subtree: true,
+        characterData: true
+      });
+
+      if (window.BOLD?.options?.app?.on) {
+        window.BOLD.options.app.on('option_changed', update);
+      }
+
+      const debounced = () => setTimeout(update, 10);
+      qtyContainer.addEventListener('click', (e) => {
+        if (e.target.closest('.integrated-quantity__button')) debounced();
+      });
+      qtyInput.addEventListener('change', update);
+
+      update(); // initial render
+    };
+
+    if (boldTotalEl) {
+      wireBold();
+    } else {
+      const appearObs = new MutationObserver(() => {
+        const found = formEl.querySelector('.bold_option_total');
+        if (found) {
+          boldTotalEl = found;
+          wireBold();
+          appearObs.disconnect();
+        }
+      });
+      appearObs.observe(formEl, { childList: true, subtree: true });
+    }
+  });
+})();

--- a/sections/product-main-recharge.liquid
+++ b/sections/product-main-recharge.liquid
@@ -47,7 +47,7 @@
 -%}
 
 
-<product-form-controller class="meal-plan-premium-layout" data-section-id="{{ section.id }}" data-promo-active="{{ promo_active }}">
+<product-form-controller class="meal-plan-premium-layout product-main" data-section-id="{{ section.id }}" data-promo-active="{{ promo_active }}">
   <div class="meal-plan-hero-container">
     <div class="meal-plan-hero-grid">
 
@@ -64,6 +64,13 @@
               {%- endif -%}
             </h1>
             <span class="meal-plan-hero__tag">Meal Plan</span>
+          </div>
+
+          <div class="product-main__price" data-legacy-pricing="true">
+            <span
+              data-product-price
+              data-base-price="{{ current_variant.price }}"
+            >{{ current_variant.price | money }}</span>
           </div>
 
           {%- if hero_hook != blank -%}
@@ -124,7 +131,7 @@
 
       <div class="meal-plan-hero__form">
         <div class="meal-plan-form-card">
-          <form method="post" action="/cart/add" accept-charset="UTF-8" class="product-form-recharge" data-product-form>
+          <form method="post" action="/cart/add" accept-charset="UTF-8" class="product-form-recharge product-main__form" data-product-form>
 
             <div class="form-step" data-order="1">
               <label for="Option-{{ section.id }}-0" class="form-step__label">
@@ -222,6 +229,8 @@
 </product-form-controller>
 
 {%- render 'footer-minimal-ordering' -%}
+
+<script src="{{ 'legacy-dynamic-price.js' | asset_url }}" defer></script>
 
 <script>
 class ProductFormController extends HTMLElement {


### PR DESCRIPTION
## Summary
- mark the legacy Recharge product section with a legacy pricing sentinel and load a dedicated price updater script
- add a section-scoped legacy price script that syncs quantity and Bold option totals into the header price display
- guard the universal Bold combined price script so it skips sections using the legacy pricing system

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6f5e7a258832f9415d644df651849