### PR TITLE
Add new icon snippets with accessible SVG defaults

### DIFF
--- a/snippets/icon-fallback.liquid
+++ b/snippets/icon-fallback.liquid
@@ -1,0 +1,13 @@
+{%- assign _size = size | default: '1em' -%}
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="{{ _size }}" height="{{ _size }}" viewBox="0 0 24 24"
+     fill="none" stroke="currentColor" stroke-width="{{ stroke_width | default: 1.8 }}"
+     stroke-linecap="round" stroke-linejoin="round"
+     class="{{ class }}" role="{{ role | default: 'img' }}"
+     {% if aria_hidden == 'true' %}aria-hidden="true"{% endif %}
+     {% if aria_labelledby and aria_labelledby != '' %}aria-labelledby="{{ aria_labelledby }}"{% endif %}>
+  {%- if title and title != '' -%}<title id="{{ title_id }}">{{ title }}</title>{%- endif -%}
+  <circle cx="12" cy="12" r="9" />
+  <path d="M12 16v-1.5c0-1.4 2-1.8 2-3.5a2 2 0 1 0-4 0" />
+  <circle cx="12" cy="18" r="0.75" />
+</svg>

--- a/snippets/icon-home-smile.liquid
+++ b/snippets/icon-home-smile.liquid
@@ -1,0 +1,15 @@
+{%- assign _size = size | default: '1em' -%}
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="{{ _size }}" height="{{ _size }}" viewBox="0 0 24 24"
+     fill="none" stroke="currentColor" stroke-width="{{ stroke_width | default: 1.8 }}"
+     stroke-linecap="round" stroke-linejoin="round"
+     class="{{ class }}" role="{{ role | default: 'img' }}"
+     {% if aria_hidden == 'true' %}aria-hidden="true"{% endif %}
+     {% if aria_labelledby and aria_labelledby != '' %}aria-labelledby="{{ aria_labelledby }}"{% endif %}>
+  {%- if title and title != '' -%}<title id="{{ title_id }}">{{ title }}</title>{%- endif -%}
+  <!-- House -->
+  <path d="M3 10.5L12 3l9 7.5V20a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+  <path d="M9 22V14h6v8" />
+  <!-- Smile -->
+  <path d="M8.5 12.5c1 .9 2.3 1.5 3.5 1.5s2.5-.6 3.5-1.5" />
+</svg>

--- a/snippets/icon-question-answer.liquid
+++ b/snippets/icon-question-answer.liquid
@@ -1,0 +1,16 @@
+{%- assign _size = size | default: '1em' -%}
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="{{ _size }}" height="{{ _size }}" viewBox="0 0 24 24"
+     fill="none" stroke="currentColor" stroke-width="{{ stroke_width | default: 1.8 }}"
+     stroke-linecap="round" stroke-linejoin="round"
+     class="{{ class }}" role="{{ role | default: 'img' }}"
+     {% if aria_hidden == 'true' %}aria-hidden="true"{% endif %}
+     {% if aria_labelledby and aria_labelledby != '' %}aria-labelledby="{{ aria_labelledby }}"{% endif %}>
+  {%- if title and title != '' -%}<title id="{{ title_id }}">{{ title }}</title>{%- endif -%}
+  <!-- Two bubbles -->
+  <path d="M15 14h-6l-4 4V6a2 2 0 0 1 2-2h11a2 2 0 0 1 2 2v6" />
+  <path d="M17 16h2a2 2 0 0 0 2-2v-1" />
+  <circle cx="8.5" cy="8.5" r="0.75" />
+  <circle cx="12" cy="8.5" r="0.75" />
+  <circle cx="15.5" cy="8.5" r="0.75" />
+</svg>

--- a/snippets/icon-restaurant.liquid
+++ b/snippets/icon-restaurant.liquid
@@ -1,0 +1,15 @@
+{%- assign _size = size | default: '1em' -%}
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="{{ _size }}" height="{{ _size }}" viewBox="0 0 24 24"
+     fill="none" stroke="currentColor" stroke-width="{{ stroke_width | default: 1.8 }}"
+     stroke-linecap="round" stroke-linejoin="round"
+     class="{{ class }}" role="{{ role | default: 'img' }}"
+     {% if aria_hidden == 'true' %}aria-hidden="true"{% endif %}
+     {% if aria_labelledby and aria_labelledby != '' %}aria-labelledby="{{ aria_labelledby }}"{% endif %}>
+  {%- if title and title != '' -%}<title id="{{ title_id }}">{{ title }}</title>{%- endif -%}
+  <!-- Cloche / serving dish -->
+  <path d="M3 17h18" />
+  <path d="M5 17a7 7 0 0 1 14 0" />
+  <path d="M12 6v2" />
+  <path d="M10 6h4" />
+</svg>

--- a/snippets/icon-star.liquid
+++ b/snippets/icon-star.liquid
@@ -1,0 +1,11 @@
+{%- assign _size = size | default: '1em' -%}
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="{{ _size }}" height="{{ _size }}" viewBox="0 0 24 24"
+     fill="none" stroke="currentColor" stroke-width="{{ stroke_width | default: 1.8 }}"
+     stroke-linecap="round" stroke-linejoin="round"
+     class="{{ class }}" role="{{ role | default: 'img' }}"
+     {% if aria_hidden == 'true' %}aria-hidden="true"{% endif %}
+     {% if aria_labelledby and aria_labelledby != '' %}aria-labelledby="{{ aria_labelledby }}"{% endif %}>
+  {%- if title and title != '' -%}<title id="{{ title_id }}">{{ title }}</title>{%- endif -%}
+  <path d="M12 3.5l2.9 5.88 6.5.95-4.7 4.58 1.1 6.44L12 18.9 6.2 21.35l1.1-6.44L2.6 10.33l6.5-.95L12 3.5z"/>
+</svg>

--- a/snippets/icon.liquid
+++ b/snippets/icon.liquid
@@ -1,0 +1,70 @@
+{%- comment -%}
+Usage:
+  {% render 'icon', name: 'restaurant' %}
+  {% render 'icon', name: 'home-smile', size: '24', class: 'text-red-600', stroke_width: 1.75, title: 'Home delivery' %}
+
+Params:
+  name          (required) : icon key ('restaurant' | 'home-smile' | 'star' | 'question-answer')
+  size          (optional) : number or string; defaults to '1em' (accepts '24', '1.25em', '24px')
+  class         (optional) : string of classes
+  stroke_width  (optional) : defaults to 1.8
+  title         (optional) : accessible title; if provided, icon is announced by AT; otherwise aria-hidden
+  decorative    (optional) : boolean; if true, forces aria-hidden (overrides title)
+{%- endcomment -%}
+
+{%- liquid
+  assign _name = name | default: ''
+  assign _size = size | default: '1em'
+  assign _stroke = stroke_width | default: 1.8
+  assign _class = class | default: ''
+  assign _decor = decorative | default: false
+  assign _title = title
+
+  capture _title_id
+    echo 'icon-' | append: _name | append: '-' | append: section.id | append: '-' | append: forloop.index0
+  endcapture
+
+  # Determine accessibility attrs
+  assign _role = 'img'
+  assign _aria_hidden = 'true'
+  assign _aria_labelledby = ''
+  if _decor == true
+    assign _aria_hidden = 'true'
+  elsif _title and _title != ''
+    assign _aria_hidden = 'false'
+    assign _aria_labelledby = _title_id
+  endif
+-%}
+
+{%- case _name -%}
+  {%- when 'restaurant' -%}
+    {%- render 'icon-restaurant',
+      size: _size, class: _class, stroke_width: _stroke,
+      title: _title, title_id: _title_id,
+      aria_hidden: _aria_hidden, aria_labelledby: _aria_labelledby, role: _role
+    -%}
+  {%- when 'home-smile' -%}
+    {%- render 'icon-home-smile',
+      size: _size, class: _class, stroke_width: _stroke,
+      title: _title, title_id: _title_id,
+      aria_hidden: _aria_hidden, aria_labelledby: _aria_labelledby, role: _role
+    -%}
+  {%- when 'star' -%}
+    {%- render 'icon-star',
+      size: _size, class: _class, stroke_width: _stroke,
+      title: _title, title_id: _title_id,
+      aria_hidden: _aria_hidden, aria_labelledby: _aria_labelledby, role: _role
+    -%}
+  {%- when 'question-answer' -%}
+    {%- render 'icon-question-answer',
+      size: _size, class: _class, stroke_width: _stroke,
+      title: _title, title_id: _title_id,
+      aria_hidden: _aria_hidden, aria_labelledby: _aria_labelledby, role: _role
+    -%}
+  {%- else -%}
+    {%- render 'icon-fallback',
+      size: _size, class: _class, stroke_width: _stroke,
+      title: _title, title_id: _title_id,
+      aria_hidden: _aria_hidden, aria_labelledby: _aria_labelledby, role: _role
+    -%}
+{%- endcase -%}


### PR DESCRIPTION
## Summary
- add a reusable `icon` snippet to route icon names to svg partials with accessibility attributes
- create restaurant, home-smile, star, question-answer, and fallback icon snippets with shared api

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68d96c030cd4832fba6fff7f6e82d6ae