### PR TITLE
fix: keep product summary in info column

### DIFF
--- a/sections/product-main-content.liquid
+++ b/sections/product-main-content.liquid
@@ -258,7 +258,6 @@
           >{{ current_variant.price | money }}</span>
         </div>
       </div>
-      </div>
       {%- assign has_highlights = false -%}
       {%- if ingredient_highlights and ingredient_highlights.value != blank -%}
         {%- assign has_highlights = true -%}


### PR DESCRIPTION
## Summary
- remove the stray closing div that ejected the product summary content from the info column
- keep the highlight detection guard without breaking the layout structure

## Testing
- not run (shopify theme)


------
https://chatgpt.com/codex/tasks/task_e_68e3b10a89c8832fa27c6f06804ab657