### PR TITLE
Stabilize collection layout viewport sizing

### DIFF
--- a/assets/app-viewport.js
+++ b/assets/app-viewport.js
@@ -1,0 +1,34 @@
+(function() {
+  if (window.__appViewportInitialized) return;
+  window.__appViewportInitialized = true;
+
+  const root = document.documentElement;
+  const setViewportHeight = () => {
+    const viewport = window.visualViewport;
+    const rawHeight = viewport ? viewport.height : window.innerHeight;
+    if (!rawHeight) return;
+    const height = Math.max(0, Math.round(rawHeight * 100) / 100);
+    root.style.setProperty('--app-viewport-height', `${height}px`);
+  };
+
+  const requestSet = () => window.requestAnimationFrame(setViewportHeight);
+
+  const attach = (target, event) => {
+    if (!target || !target.addEventListener) return;
+    target.addEventListener(event, requestSet, { passive: true });
+  };
+
+  attach(window, 'resize');
+  attach(window, 'orientationchange');
+
+  if (window.visualViewport) {
+    attach(window.visualViewport, 'resize');
+    attach(window.visualViewport, 'scroll');
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', setViewportHeight, { once: true });
+  } else {
+    setViewportHeight();
+  }
+})();

--- a/assets/custom.css
+++ b/assets/custom.css
@@ -103,6 +103,7 @@ button.btn.benefitbadge.badgeallergen { background-color: #eec877; }
   --page-background: #f0f2f5;
   --color-body: #f0f2f5;
   --color-bg: #f0f2f5;
+  --app-viewport-height: 100dvh;
 }
 
 body,
@@ -123,23 +124,20 @@ body.collection-menu-open {
   display: grid;
   grid-template-columns: 1fr 380px;
   height: calc(
-    100dvh - var(--app-header-min-height) - var(--app-footer-min-height)
+    var(--app-viewport-height, 100dvh) - var(--app-header-min-height) -
+    var(--app-footer-min-height)
   );
 }
 
 @supports not (height: 100dvh) {
-  .collection-page__layout {
-    height: calc(
-      100svh - var(--app-header-min-height) - var(--app-footer-min-height)
-    );
+  :root {
+    --app-viewport-height: 100svh;
   }
 }
 
 @supports not (height: 100svh) {
-  .collection-page__layout {
-    height: calc(
-      100vh - var(--app-header-min-height) - var(--app-footer-min-height)
-    );
+  :root {
+    --app-viewport-height: 100vh;
   }
 }
 
@@ -147,6 +145,12 @@ body.collection-menu-open {
   height: 100%;
   padding-right: 0;
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.collection-page__sidebar > .cart-sidebar-section-wrapper {
+  max-height: 100%;
 }
 
 .collection-page__main {
@@ -804,11 +808,11 @@ body.template-suffix--meal-plans .collection-selector__toggle {
   line-height: 0; color: #6c757d; border-radius: 50%; transition: all 0.2s ease;
 }
 .cart-drawer__close-btn:hover { color: var(--brand-text); background-color: #e9ecef; }
-.cart-sidebar-section-wrapper { position: relative; height: 100%; display: flex !important; flex-direction: column !important; }
+.cart-sidebar-section-wrapper { position: relative; height: 100%; max-height: 100%; display: flex !important; flex-direction: column !important; }
 .cart-sidebar {
   background-color: #fdfdfd !important; box-shadow: -2px 0 10px rgba(0, 0, 0, 0.03) !important;
   border-radius: 0 !important; display: flex !important; flex-direction: column !important;
-  height: 100% !important; min-height: 100% !important; overflow: hidden !important; flex: 1 1 auto !important;
+  height: 100% !important; max-height: 100% !important; min-height: 0 !important; overflow: hidden !important; flex: 1 1 auto !important;
 }
 .cart-sidebar__content {
   display: flex !important;
@@ -4224,20 +4228,20 @@ body[class*='product-custom-meals'] .cart-drawer__property .ingredient-name {
 /* Use the most accurate unit available, with safe fallbacks */
 .full-viewport {
   /* modern browsers */
-  min-height: calc(100dvh - var(--app-header-min-height) - var(--app-footer-min-height));
+  min-height: calc(var(--app-viewport-height, 100dvh) - var(--app-header-min-height) - var(--app-footer-min-height));
 }
 
 @supports not (height: 100dvh) {
   .full-viewport {
     /* static/“small” viewport on Safari to avoid URL-bar jump */
-    min-height: calc(100svh - var(--app-header-min-height) - var(--app-footer-min-height));
+    min-height: calc(var(--app-viewport-height, 100svh) - var(--app-header-min-height) - var(--app-footer-min-height));
   }
 }
 
 @supports not (height: 100svh) {
   .full-viewport {
     /* legacy fallback */
-    min-height: calc(100vh - var(--app-header-min-height) - var(--app-footer-min-height));
+    min-height: calc(var(--app-viewport-height, 100vh) - var(--app-header-min-height) - var(--app-footer-min-height));
   }
 }
 

--- a/layout/product-shell.liquid
+++ b/layout/product-shell.liquid
@@ -381,6 +381,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 	</script>
 	{% render 'structured-data' %}
 
+        <script defer src="{{ 'app-viewport.js' | asset_url }}"></script>
         <script defer type="module" src="{{ 'theme.js' | asset_url }}"></script>
         <script defer nomodule src="{{ 'theme.legacy.js' | asset_url }}"></script>
   <script defer src="{{ 'cart-preview-sidebar.js' | asset_url }}"></script>

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -317,6 +317,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 	</script>
 	{% render 'structured-data' %}
 
+        <script defer src="{{ 'app-viewport.js' | asset_url }}"></script>
         <script defer type="module" src="{{ 'theme.js' | asset_url }}"></script>
         <script defer nomodule src="{{ 'theme.legacy.js' | asset_url }}"></script>
   <script defer src="{{ 'cart-preview-sidebar.js' | asset_url }}"></script>


### PR DESCRIPTION
## Summary
- introduce an app viewport helper script that keeps a CSS variable in sync with the real viewport height
- update collection and cart sidebar styles to use the synced height and prevent the sidebar column from stretching past the viewport
- load the helper script across both theme shells so layout variants share the stable viewport calculation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e437cd8ebc832f9cd457bcd247ae36