### PR TITLE
Fix missing closing main tag on product template

### DIFF
--- a/templates/product.liquid
+++ b/templates/product.liquid
@@ -45,7 +45,7 @@
           {% section 'template--product--recommendations' %}
         </div>
 
-    </main
+    </main>
 
     <aside class="collection-page__sidebar">
       {% render 'cart-preview-sidebar' %}


### PR DESCRIPTION
## Summary
- add the missing closing main tag in the product template layout
- ensure the product page shares the same stable grid structure as the collection page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4412dab90832fb0dd401831a7a98b