### PR TITLE
Make Yotpo loader configurable via theme setting

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -2,6 +2,12 @@
    ICON MEALS - CUSTOM STYLESHEET - V17.0 (WORLD-CLASS ANIMATION REFACTOR)
    ========================================================================== */
 
+/* PDP: reserve space for Yotpo bottom line to prevent layout shift */
+body.template-product .yotpo.bottomLine {
+  min-height: 28px;
+  display: block;
+}
+
 /* ==========================================================================
    WORLD-CLASS ANIMATIONS & LOADERS (V2.1 - DEFINITIVE FIX)
    ========================================================================== */

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -2351,5 +2351,15 @@
         "label": "Box 1 savings for 24-meal plan"
       }
     ]
+  },
+  {
+    "name": "Integrations",
+    "settings": [
+      {
+        "type": "text",
+        "id": "yotpo_app_key",
+        "label": "Yotpo app key"
+      }
+    ]
   }
 ]

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -160,6 +160,23 @@
     {{ 'macro-calculator.css' | asset_url | stylesheet_tag }}
     {% endif %}
     <!-- cedriclajato.com end code -->
+  <!-- Yotpo Reviews: global widget loader -->
+  <script>
+    (function () {
+      if (window.__yotpoLoaderInitialized) return;
+      if (window.Yotpo || document.querySelector('script[src*="staticw2.yotpo.com"]')) return;
+      var appKey = {{ settings.yotpo_app_key | json }};
+      if (!appKey) return;
+      var script = document.createElement('script');
+      script.type = 'text/javascript';
+      script.async = true;
+      script.src = 'https://staticw2.yotpo.com/' + appKey + '/widget.js';
+      var firstScript = document.getElementsByTagName('script')[0];
+      firstScript.parentNode.insertBefore(script, firstScript);
+      window.__yotpoLoaderInitialized = true;
+    })();
+  </script>
+
   <script type="text/javascript">
     (function(c,l,a,r,i,t,y){
         c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};

--- a/sections/product-main-content.liquid
+++ b/sections/product-main-content.liquid
@@ -250,7 +250,16 @@
               {{ product.title }}
             {% endif %}
           </h1>
-          <div class="reviews-placeholder"><span class="yotpo-display-wrapper"></span></div>
+          <div
+            class="yotpo bottomLine"
+            data-product-id="{{ product.id }}"
+            data-name="{{ product.title | escape }}"
+            data-url="{{ shop.url }}{{ product.url }}"
+            {% if product.featured_image %}
+              data-image-url="{{ product.featured_image | image_url: width: 1024 }}"
+            {% endif %}
+            data-description="{{ product.description | strip_html | escape }}"
+          ></div>
           <div class="product-main__price"{% if product.handle == 'custom-meals' or product.handle == 'custom-breakfast' %} data-legacy-pricing="true"{% endif %}>
             <span
               data-product-price


### PR DESCRIPTION
## Summary
- read the Yotpo widget loader key from a theme setting and add an extra guard against duplicate scripts
- scope the CLS guard for the bottomLine stars to product templates only
- expose a new Integrations section in theme settings for managing the Yotpo app key

## Testing
- not run (liquid/theme change)

------
https://chatgpt.com/codex/tasks/task_e_68e52a311be8832fbf9c1580e10fe093