### PR TITLE
Move PDP reviews into dedicated full-width section

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -4419,24 +4419,36 @@ body.template-product .yotpo.bottomLine .yotpo-stars {
   transform: translateY(1px);
 }
 
-/* Full reviews widget container */
-body.template-product .yotpo-main-widget,
-body.template-product .yotpo.yotpo-main-widget {
+body.template-product #recharge-bundle-wrapper,
+body.template-product .rc-widget-injection-parent {
+  min-height: 56px;
+  display: block;
+}
+
+/* PDP Reviews Full Width */
+body.template-product .pdp-reviews-fullwidth {
   margin-top: 2rem;
-  padding-top: 1rem;
-  border-top: 1px solid #eaeaea;
+  margin-bottom: 2rem;
+}
+
+body.template-product .pdp-reviews__heading {
+  text-align: center;
+  font-weight: 700;
+  margin-bottom: 1rem;
+  color: var(--brand-text, #212529);
+}
+
+body.template-product .pdp-reviews__container {
+  width: 100%;
+}
+
+body.template-product .pdp-reviews--boxed .pdp-reviews__container {
   max-width: 900px;
   margin-left: auto;
   margin-right: auto;
 }
 
 body.template-product #yotpo-main-widget {
-  scroll-margin-top: 6rem; /* Prevent header overlap */
-}
-
-body.template-product #recharge-bundle-wrapper,
-body.template-product .rc-widget-injection-parent {
-  min-height: 56px;
-  display: block;
+  scroll-margin-top: 6rem;
 }
 

--- a/sections/apps.liquid
+++ b/sections/apps.liquid
@@ -1,7 +1,6 @@
 {% comment %} REMOVED: Conditional '.container--product-page' wrapper to allow this section to live inside the main product grid. {% endcomment %}
 {%- if template.name == 'product' -%}
   {%- if content_for_header contains 'yotpo' -%}
-    <a id="yotpo-main-widget"></a>
   {%- endif -%}
 {%- endif -%}
 <div class="apps-section-wrapper {% if section.settings.include_margins %}has-theme-margins{% endif %}">

--- a/sections/product-main-content.liquid
+++ b/sections/product-main-content.liquid
@@ -381,6 +381,7 @@
   </div>
 </div>
 
+{%- section 'product-reviews-fullwidth' -%}
 {%- render 'footer-minimal-ordering' -%}
 <script type="application/json" data-product-json>{{ product | json }}</script>
 {% if product.handle == 'custom-meals' or product.handle == 'custom-breakfast' %}
@@ -389,138 +390,25 @@
 
 <script>
 (function() {
-  const WIDGET_SELECTOR = '.yotpo-main-widget, .yotpo.yotpo-main-widget, .yotpo-widget-instance';
-
-  function findInjectionPoint() {
-    return (
-      document.querySelector('.product-page-additional-sections') ||
-      document.querySelector('#CollectionProductGrid') ||
-      document.querySelector('.product-main__info-column') ||
-      document.body
-    );
-  }
-
-  function insertAfter(referenceNode, newNode) {
-    if (!referenceNode) {
-      document.body.appendChild(newNode);
-      return newNode;
-    }
-
-    if (referenceNode === document.body || referenceNode.parentNode === document.documentElement) {
-      document.body.appendChild(newNode);
-      return newNode;
-    }
-
-    if (referenceNode.parentNode) {
-      return referenceNode.parentNode.insertBefore(newNode, referenceNode.nextSibling);
-    }
-
-    if (typeof referenceNode.appendChild === 'function') {
-      referenceNode.appendChild(newNode);
-      return newNode;
-    }
-
-    document.body.appendChild(newNode);
-    return newNode;
-  }
-
   function uniqueAnchor() {
     const anchors = Array.from(document.querySelectorAll('#yotpo-main-widget'));
-    if (anchors.length <= 1) {
-      return anchors[0] || null;
+    if (anchors.length > 1) {
+      anchors.slice(1).forEach((anchor) => anchor.remove());
     }
-
-    const keeper = anchors[0];
-    anchors.slice(1).forEach((node) => {
-      if (node && node.parentNode) {
-        node.parentNode.removeChild(node);
-      }
-    });
-    return keeper;
-  }
-
-  function ensureAnchor() {
-    let anchor = uniqueAnchor();
-    if (anchor) {
-      return anchor;
-    }
-
-    anchor = document.createElement('a');
-    anchor.id = 'yotpo-main-widget';
-    anchor.setAttribute('aria-hidden', 'true');
-    anchor.style.display = 'block';
-    anchor.style.position = 'relative';
-    anchor.style.height = '0';
-
-    const target = findInjectionPoint();
-    return insertAfter(target, anchor);
   }
 
   function coerceBottomLineHref() {
-    const wanted = '#yotpo-main-widget';
-    const links = document.querySelectorAll('.yotpo.bottomLine a[href^="#"]');
-    links.forEach((link) => {
-      if (link.getAttribute('href') !== wanted) {
-        link.setAttribute('href', wanted);
-      }
-    });
-  }
-
-  function getWidgets() {
-    return Array.from(document.querySelectorAll(WIDGET_SELECTOR));
-  }
-
-  function widgetExists() {
-    return getWidgets().length > 0;
-  }
-
-  function injectFallbackWidget(anchor) {
-    if (widgetExists()) {
-      return;
-    }
-
-    const mountAnchor = anchor || ensureAnchor();
-    const appsWrapper = document.querySelector('.apps-section-wrapper');
-
-    const fallback = document.createElement('div');
-    fallback.className = 'yotpo yotpo-main-widget';
-    fallback.setAttribute('data-product-id', '{{ product.id }}');
-    fallback.setAttribute('data-name', {{ product.title | json }});
-    fallback.setAttribute('data-url', {{ shop.url | append: product.url | json }});
-    {% if product.featured_image %}
-    fallback.setAttribute('data-image-url', '{{ product.featured_image | image_url: width: 1024 }}');
-    {% endif %}
-    fallback.setAttribute('data-description', {{ product.description | strip_html | truncate: 300 | json }});
-    fallback.dataset.fallbackYotpo = 'true';
-
-    if (appsWrapper) {
-      appsWrapper.appendChild(fallback);
-    } else if (mountAnchor) {
-      insertAfter(mountAnchor, fallback);
-    } else {
-      findInjectionPoint().appendChild(fallback);
-    }
-  }
-
-  function pruneFallbackWidgets() {
-    const widgets = getWidgets();
-    if (widgets.length <= 1) {
-      return;
-    }
-
-    const fallback = widgets.find((node) => node.dataset && node.dataset.fallbackYotpo === 'true');
-    const realWidget = widgets.find((node) => !node.dataset || node.dataset.fallbackYotpo !== 'true');
-
-    if (fallback && realWidget) {
-      fallback.remove();
+    const link = document.querySelector('.yotpo.bottomLine a[href^="#"]');
+    if (link && link.getAttribute('href') !== '#yotpo-main-widget') {
+      link.setAttribute('href', '#yotpo-main-widget');
     }
   }
 
   function hydrateYotpo() {
     if (window.Yotpo) {
-      const refresh = window.Yotpo.refreshWidgets || window.Yotpo.initWidgets;
-      if (typeof refresh === 'function') {
-        refresh.call(window.Yotpo);
+      const fn = window.Yotpo.refreshWidgets || window.Yotpo.initWidgets;
+      if (typeof fn === 'function') {
+        fn.call(window.Yotpo);
       }
     }
   }
@@ -532,49 +420,34 @@
         const link = event.target.closest('.yotpo.bottomLine a[href^="#"]');
         if (!link) return;
 
-        const anchor = ensureAnchor();
-        if (!anchor) return;
+        const target = document.querySelector('#yotpo-main-widget');
+        if (!target) return;
 
         event.preventDefault();
-        anchor.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        target.scrollIntoView({ behavior: 'smooth', block: 'start' });
       },
       { passive: false }
     );
   }
 
-  function hydrateCycle() {
-    const anchor = ensureAnchor();
-    coerceBottomLineHref();
-    pruneFallbackWidgets();
-
-    if (!widgetExists()) {
-      injectFallbackWidget(anchor);
-    }
-
-    hydrateYotpo();
-  }
-
   function init() {
-    wireSmoothScroll();
-    hydrateCycle();
-
-    let attempts = 0;
-    const poller = setInterval(() => {
-      hydrateCycle();
-      attempts += 1;
-      if (attempts > 20 || widgetExists()) {
-        clearInterval(poller);
-      }
-    }, 300);
+    uniqueAnchor();
+    coerceBottomLineHref();
+    hydrateYotpo();
 
     document.addEventListener('shopify:section:load', () => {
-      hydrateCycle();
+      uniqueAnchor();
+      coerceBottomLineHref();
+      hydrateYotpo();
     });
 
     document.addEventListener('yotpo:widgetLoaded', () => {
-      hydrateCycle();
+      uniqueAnchor();
+      coerceBottomLineHref();
     });
   }
+
+  wireSmoothScroll();
 
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', init, { once: true });

--- a/sections/product-reviews-fullwidth.liquid
+++ b/sections/product-reviews-fullwidth.liquid
@@ -1,0 +1,36 @@
+{% comment %}
+  PDP Reviews (Full Width)
+  Renders Yotpo main widget at full width within the left column above the footer.
+{% endcomment %}
+
+<section class="pdp-reviews-fullwidth {% if section.settings.boxed_container %}pdp-reviews--boxed{% endif %}" data-section-type="pdp-reviews-fullwidth">
+  <a id="yotpo-main-widget"></a>
+
+  {% if section.settings.heading != blank %}
+    <h2 class="pdp-reviews__heading">{{ section.settings.heading }}</h2>
+  {% endif %}
+
+  <div class="pdp-reviews__container">
+    <div class="yotpo yotpo-main-widget"
+      data-product-id="{{ product.id }}"
+      data-name="{{ product.title | escape }}"
+      data-url="{{ shop.url }}{{ product.url }}"
+      {% if product.featured_image %}
+        data-image-url="{{ product.featured_image | image_url: width: 1024 }}"
+      {% endif %}
+      data-description="{{ product.description | strip_html | truncate: 300 | escape }}">
+    </div>
+  </div>
+</section>
+
+{% schema %}
+{
+  "name": "PDP Reviews (Full Width)",
+  "tag": "section",
+  "settings": [
+    { "type": "text", "id": "heading", "label": "Heading", "default": "Customer Reviews" },
+    { "type": "checkbox", "id": "boxed_container", "label": "Boxed container (900px max)", "default": true }
+  ],
+  "templates": ["product"]
+}
+{% endschema %}


### PR DESCRIPTION
## Summary
- add a dedicated `product-reviews-fullwidth` section that renders the Yotpo widget across the PDP content width with optional heading and boxed layout
- include the new section in the PDP main content and simplify the Yotpo helper script to handle anchors, smooth scrolling, and widget refresh without fallback injection
- remove the redundant Yotpo anchor from the apps section and add light styling to support the new layout

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e53eb71b98832fb0655803f38f37d7