### PR TITLE
Fix product reviews rendering within main content

### DIFF
--- a/sections/product-main-content.liquid
+++ b/sections/product-main-content.liquid
@@ -381,7 +381,7 @@
   </div>
 </div>
 
-{%- section 'product-reviews-fullwidth' -%}
+{%- render 'product-reviews-fullwidth', heading: section.settings.reviews_heading, boxed_container: section.settings.reviews_boxed_container -%}
 {%- render 'footer-minimal-ordering' -%}
 <script type="application/json" data-product-json>{{ product | json }}</script>
 {% if product.handle == 'custom-meals' or product.handle == 'custom-breakfast' %}
@@ -565,6 +565,18 @@
       "type": "richtext",
       "id": "default_faq",
       "label": "Default FAQ content"
+    },
+    {
+      "type": "text",
+      "id": "reviews_heading",
+      "label": "Reviews heading",
+      "default": "Customer Reviews"
+    },
+    {
+      "type": "checkbox",
+      "id": "reviews_boxed_container",
+      "label": "Box reviews content",
+      "default": true
     }
   ],
   "blocks": [

--- a/snippets/product-reviews-fullwidth.liquid
+++ b/snippets/product-reviews-fullwidth.liquid
@@ -1,0 +1,30 @@
+{%- comment -%}
+  PDP Reviews snippet used inside product main content.
+  Mirrors the original section markup while avoiding nested sections.
+{%- endcomment -%}
+{%- assign reviews_heading = heading | default: 'Customer Reviews' -%}
+{%- if boxed_container == nil -%}
+  {%- assign reviews_boxed_container = true -%}
+{%- else -%}
+  {%- assign reviews_boxed_container = boxed_container -%}
+{%- endif -%}
+
+<section class="pdp-reviews-fullwidth{% if reviews_boxed_container %} pdp-reviews--boxed{% endif %}" data-section-type="pdp-reviews-fullwidth">
+  <a id="yotpo-main-widget"></a>
+
+  {%- if reviews_heading != blank -%}
+    <h2 class="pdp-reviews__heading">{{ reviews_heading }}</h2>
+  {%- endif -%}
+
+  <div class="pdp-reviews__container">
+    <div class="yotpo yotpo-main-widget"
+      data-product-id="{{ product.id }}"
+      data-name="{{ product.title | escape }}"
+      data-url="{{ shop.url }}{{ product.url }}"
+      {%- if product.featured_image -%}
+        data-image-url="{{ product.featured_image | image_url: width: 1024 }}"
+      {%- endif -%}
+      data-description="{{ product.description | strip_html | truncate: 300 | escape }}">
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
## Summary
- replace the nested reviews section call with a snippet render to avoid Liquid errors on the PDP
- add configuration settings so the reviews snippet can control its heading and boxed layout
- introduce a reusable `product-reviews-fullwidth` snippet mirroring the previous section markup

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e540d30dc8832fb49eb039e6d3790b