### PR TITLE
Add configurable Yotpo Star Rating widget to PDP

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -2,10 +2,13 @@
    ICON MEALS - CUSTOM STYLESHEET - V17.0 (WORLD-CLASS ANIMATION REFACTOR)
    ========================================================================== */
 
-/* PDP: reserve space for Yotpo bottom line to prevent layout shift */
-body.template-product .yotpo.bottomLine {
-  min-height: 28px;
-  display: block;
+/* PDP title row — accommodate star rating widget */
+body.template-product .product-review-stars {
+  margin-top: 0.25rem;
+  margin-bottom: 0.5rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
 }
 
 /* PDP APP-SHELL (DESKTOP) ------------------------------------------------ */
@@ -4393,15 +4396,7 @@ body[class*='product-custom-meals'] .cart-drawer__property .ingredient-name {
 
 /* PDP - Yotpo Reviews Styling ---------------------------------------------- */
 
-body.template-product .product-review-stars {
-  margin-top: 0.4rem;
-  margin-bottom: 0.6rem;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.25rem;
-}
-
-body.template-product .yotpo.bottomLine a {
+body.template-product .product-review-stars a {
   font-family: inherit;
   font-size: 0.95rem;
   font-weight: 500;
@@ -4410,12 +4405,12 @@ body.template-product .yotpo.bottomLine a {
   transition: color 0.25s ease;
 }
 
-body.template-product .yotpo.bottomLine a:hover {
+body.template-product .product-review-stars a:hover {
   color: var(--brand-accent, #E1261C);
   text-decoration: underline;
 }
 
-body.template-product .yotpo.bottomLine .yotpo-stars {
+body.template-product .product-review-stars .yotpo-stars {
   transform: translateY(1px);
 }
 

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -2359,6 +2359,12 @@
         "type": "text",
         "id": "yotpo_app_key",
         "label": "Yotpo app key"
+      },
+      {
+        "type": "text",
+        "id": "yotpo_star_instance_id",
+        "label": "Yotpo Star Rating (instance id)",
+        "info": "Get this from Yotpo → On-Site Widgets → Star Rating → View Instructions → Get the code."
       }
     ]
   }

--- a/sections/product-main-content.liquid
+++ b/sections/product-main-content.liquid
@@ -250,16 +250,19 @@
               {{ product.title }}
             {% endif %}
           </h1>
-          <div
-            class="yotpo bottomLine product-review-stars"
-            data-product-id="{{ product.id }}"
-            data-name="{{ product.title | escape }}"
-            data-url="{{ shop.url }}{{ product.url }}"
-            {% if product.featured_image %}
-              data-image-url="{{ product.featured_image | image_url: width: 1024 }}"
-            {% endif %}
-            data-description="{{ product.description | strip_html | truncate: 300 | escape }}"
-          ></div>
+          <div class="product-review-stars">
+            <div
+              class="yotpo-widget-instance"
+              data-yotpo-instance-id="{{ settings.yotpo_star_instance_id }}"
+              data-yotpo-product-id="{{ product.id }}"
+              data-yotpo-name="{{ product.title | escape }}"
+              data-yotpo-url="{{ shop.url }}{{ product.url }}"
+              {% if product.featured_image %}
+                data-yotpo-image-url="{{ product.featured_image | image_url: width: 1024 }}"
+              {% endif %}
+              data-yotpo-description="{{ product.description | strip_html | truncate: 300 | escape }}"
+            ></div>
+          </div>
           <div class="product-main__price"{% if product.handle == 'custom-meals' or product.handle == 'custom-breakfast' %} data-legacy-pricing="true"{% endif %}>
             <span
               data-product-price
@@ -397,11 +400,19 @@
     }
   }
 
-  function coerceBottomLineHref() {
-    const link = document.querySelector('.yotpo.bottomLine a[href^="#"]');
-    if (link && link.getAttribute('href') !== '#yotpo-main-widget') {
-      link.setAttribute('href', '#yotpo-main-widget');
-    }
+  function coerceYotpoHref() {
+    const selectors = [
+      '.yotpo.bottomLine a[href^="#"]',
+      '.yotpo-widget-instance a[href^="#"]',
+    ];
+
+    selectors.forEach((selector) => {
+      Array.from(document.querySelectorAll(selector)).forEach((link) => {
+        if (link.getAttribute('href') !== '#yotpo-main-widget') {
+          link.setAttribute('href', '#yotpo-main-widget');
+        }
+      });
+    });
   }
 
   function hydrateYotpo() {
@@ -417,7 +428,9 @@
     document.addEventListener(
       'click',
       (event) => {
-        const link = event.target.closest('.yotpo.bottomLine a[href^="#"]');
+        const link = event.target.closest(
+          '.yotpo.bottomLine a[href^="#"], .yotpo-widget-instance a[href^="#"]'
+        );
         if (!link) return;
 
         const target = document.querySelector('#yotpo-main-widget');
@@ -432,18 +445,18 @@
 
   function init() {
     uniqueAnchor();
-    coerceBottomLineHref();
+    coerceYotpoHref();
     hydrateYotpo();
 
     document.addEventListener('shopify:section:load', () => {
       uniqueAnchor();
-      coerceBottomLineHref();
+      coerceYotpoHref();
       hydrateYotpo();
     });
 
     document.addEventListener('yotpo:widgetLoaded', () => {
       uniqueAnchor();
-      coerceBottomLineHref();
+      coerceYotpoHref();
     });
   }
 


### PR DESCRIPTION
## Summary
- replace the PDP bottom line placeholder with the Yotpo Star Rating 3.0 widget instance and keep smooth scrolling to the reviews section
- add a theme setting so merchants can provide the star rating instance ID without editing code
- tweak the PDP star rating styles to match the new widget structure

## Testing
- not run (Shopify theme)

------
https://chatgpt.com/codex/tasks/task_e_68e576951b54832f8c4739b252f6c07a