### PR TITLE
Fix desktop scroll regression

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -13,9 +13,8 @@ body.template-product .product-review-stars {
 
 /* PDP APP-SHELL (DESKTOP) ------------------------------------------------ */
 @media (min-width: 992px) {
-  html,
   body.template-product {
-    height: 100%;
+    height: var(--app-viewport-height, 100dvh);
     overflow: hidden; /* the document no longer scrolls on desktop PDP */
   }
 
@@ -4332,7 +4331,6 @@ body[class*='product-custom-meals'] .cart-drawer__property .ingredient-name {
    ========================================================================== */
 /* PDP MOBILE: natural document scroll, no nested scroll, no URL-bar jank */
 @media (max-width: 991.98px) {
-  html,
   body.template-product {
     height: auto;
     overflow: auto;


### PR DESCRIPTION
## Summary
- scope the PDP scroll locking rules to product templates only
- keep the product collection layout using the viewport height variable without locking other pages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e585b21000832f86aedde24a3b96ce