### PR TITLE
Fix Recharge whitespace on PDP purchase card

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -198,6 +198,50 @@ body.collection-menu-open {
 }
 
 .container--collection-page { margin: 0 auto; padding: 0; }
+
+/* PDP PURCHASE CARD — RECHARGE WHITESPACE FIX -------------------------------- */
+body.template-product #PageContainer .product-purchase-card {
+  gap: 0.75rem;
+}
+
+body.template-product #PageContainer .product-purchase-card .product-main__options {
+  display: grid;
+  gap: 0.75rem;
+  align-content: start;
+}
+
+body.template-product #PageContainer .product-purchase-card .product-main__options > * {
+  margin: 0;
+}
+
+body.template-product #PageContainer .product-purchase-card .rc-widget-injection-parent {
+  min-height: 3.5rem;
+  margin: 0;
+  padding: 0;
+  transition: min-height 0.2s ease;
+}
+
+body.template-product #PageContainer .product-purchase-card .rc-widget-injection-parent.is-ready,
+body.template-product #PageContainer .product-purchase-card .rc-widget-injection-parent.is-empty {
+  min-height: 0;
+}
+
+body.template-product #PageContainer .product-purchase-card .rc-widget-injection-parent.is-empty {
+  display: none;
+}
+
+body.template-product #PageContainer .product-purchase-card .rc-widget-injection-parent > *,
+body.template-product #PageContainer .product-purchase-card .rc-widget,
+body.template-product #PageContainer .product-purchase-card .rc-inline,
+body.template-product #PageContainer .product-purchase-card .rc-options,
+body.template-product #PageContainer .product-purchase-card .rc-template__legacy {
+  margin-top: 0 !important;
+  margin-bottom: 0 !important;
+}
+
+body.template-product #PageContainer .product-purchase-card .product-main__actions {
+  margin-top: 0;
+}
 .collection-wrapper,
 .main-body-wrapper { overflow: visible !important; }
 

--- a/sections/product-main-content.liquid
+++ b/sections/product-main-content.liquid
@@ -299,7 +299,7 @@
       </div>
 
       <!-- 2. The "Action" Card -->
-      {%- form 'product', product, class: 'product-main__form', data-product-form: '' -%}
+      {%- form 'product', product, class: 'product-main__form product-purchase-card', data-product-form: '' -%}
         <div class="product-main__options">
           <input type="hidden" name="id" value="{{ current_variant.id }}" data-product-variant-id>
           {%- unless product.has_only_default_variant -%}
@@ -471,11 +471,46 @@
 </script>
 
 <script>
+  function initRechargeGapGuard(root) {
+    if (!root) return;
+    root.querySelectorAll('.product-purchase-card .rc-widget-injection-parent').forEach((slot) => {
+      if (slot.dataset.gapGuard === 'true') return;
+      slot.dataset.gapGuard = 'true';
+      slot.classList.add('is-hydrating');
+
+      const applyState = (forceCollapse = false) => {
+        const hasContent = slot.childElementCount > 0 || slot.textContent.trim() !== '';
+        if (hasContent) {
+          slot.classList.add('is-ready');
+          slot.classList.remove('is-empty', 'is-hydrating');
+        } else if (forceCollapse) {
+          slot.classList.remove('is-ready', 'is-hydrating');
+          slot.classList.add('is-empty');
+        }
+      };
+
+      applyState(false);
+
+      const observer = new MutationObserver(() => {
+        applyState(!slot.classList.contains('is-hydrating'));
+      });
+
+      observer.observe(slot, { childList: true, subtree: true });
+
+      window.setTimeout(() => applyState(true), 1800);
+    });
+  }
+
   document.addEventListener('DOMContentLoaded', () => {
     const sectionEl = document.querySelector('.product-main[data-section-id="{{ section.id }}"]');
     if (!sectionEl) return;
+    initRechargeGapGuard(sectionEl);
     new AjaxFormHandler(sectionEl);
     new IntegratedQuantityController(sectionEl);
+  });
+
+  document.addEventListener('shopify:section:load', (event) => {
+    initRechargeGapGuard(event.target);
   });
 
   class AjaxFormHandler {


### PR DESCRIPTION
## Summary
- add a dedicated `product-purchase-card` hook and scoped CSS to keep Recharge spacing tight on PDPs
- normalize Recharge widget margins while keeping a short hydration min-height that collapses once content renders or stays empty
- introduce a lightweight MutationObserver helper that toggles the Recharge wrapper state so empty slots disappear without layout shift

## Testing
- not run (Shopify theme preview unavailable in container)

## Notes
- Pages tested: not verified (preview unavailable in container)
- Screenshots: not captured (preview unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e653a109b0832f96e1b18051a8d0ba