### PR TITLE
Polish PDP reviews section layout and heading

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -4464,15 +4464,49 @@ body.template-product .rc-widget-injection-parent {
 
 /* PDP Reviews Full Width */
 body.template-product .pdp-reviews-fullwidth {
+  --pdp-reviews-column-padding: 1.5rem;
   margin-top: 2rem;
   margin-bottom: 2rem;
+  margin-left: calc(var(--pdp-reviews-column-padding) * -1);
+  margin-right: calc(var(--pdp-reviews-column-padding) * -1);
+  padding-left: var(--pdp-reviews-column-padding);
+  padding-right: var(--pdp-reviews-column-padding);
+  padding-top: clamp(1.25rem, 3vw, 2rem);
+  padding-bottom: clamp(1.25rem, 3vw, 2rem);
+  background-color: #fff;
+}
+
+body.template-product .pdp-reviews__inner {
+  width: 100%;
+}
+
+body.template-product .pdp-reviews__header {
+  text-align: center;
+  margin: 0 auto 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
 }
 
 body.template-product .pdp-reviews__heading {
-  text-align: center;
-  font-weight: 700;
-  margin-bottom: 1rem;
+  margin: 0;
+  font-family: var(--font-heading-family, 'Montserrat', sans-serif);
+  font-weight: 800;
   color: var(--brand-text, #212529);
+  font-size: clamp(1.5rem, 2.2vw, 1.75rem);
+  letter-spacing: 0.01em;
+}
+
+body.template-product .pdp-reviews__subheading {
+  margin: 0;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  font-family: var(--font-body-family, 'Montserrat', sans-serif);
+  font-size: clamp(0.85rem, 1.3vw, 0.95rem);
+  font-weight: 600;
+  color: rgba(33, 37, 41, 0.72);
+  background-color: rgba(33, 37, 41, 0.08);
 }
 
 body.template-product .pdp-reviews__container {
@@ -4487,5 +4521,22 @@ body.template-product .pdp-reviews--boxed .pdp-reviews__container {
 
 body.template-product #yotpo-main-widget {
   scroll-margin-top: 6rem;
+}
+
+@media (max-width: 767px) {
+  body.template-product .pdp-reviews-fullwidth {
+    --pdp-reviews-column-padding: 1rem;
+    padding-top: 1.25rem;
+    padding-bottom: 1.25rem;
+  }
+
+  body.template-product .pdp-reviews__header {
+    margin-bottom: 1.5rem;
+    gap: 0.6rem;
+  }
+
+  body.template-product .pdp-reviews__subheading {
+    padding: 0.3rem 0.75rem;
+  }
 }
 

--- a/sections/product-reviews-fullwidth.liquid
+++ b/sections/product-reviews-fullwidth.liquid
@@ -4,21 +4,31 @@
 {% endcomment %}
 
 <section class="pdp-reviews-fullwidth {% if section.settings.boxed_container %}pdp-reviews--boxed{% endif %}" data-section-type="pdp-reviews-fullwidth">
-  <a id="yotpo-main-widget"></a>
+  <div class="pdp-reviews__inner">
+    <a id="yotpo-main-widget"></a>
 
-  {% if section.settings.heading != blank %}
-    <h2 class="pdp-reviews__heading">{{ section.settings.heading }}</h2>
-  {% endif %}
+    {% if section.settings.heading != blank or section.settings.subheading != blank %}
+      <div class="pdp-reviews__header">
+        {% if section.settings.heading != blank %}
+          <h2 class="pdp-reviews__heading">{{ section.settings.heading }}</h2>
+        {% endif %}
 
-  <div class="pdp-reviews__container">
-    <div class="yotpo yotpo-main-widget"
-      data-product-id="{{ product.id }}"
-      data-name="{{ product.title | escape }}"
-      data-url="{{ shop.url }}{{ product.url }}"
-      {% if product.featured_image %}
-        data-image-url="{{ product.featured_image | image_url: width: 1024 }}"
-      {% endif %}
-      data-description="{{ product.description | strip_html | truncate: 300 | escape }}">
+        {% if section.settings.subheading != blank %}
+          <p class="pdp-reviews__subheading">{{ section.settings.subheading }}</p>
+        {% endif %}
+      </div>
+    {% endif %}
+
+    <div class="pdp-reviews__container">
+      <div class="yotpo yotpo-main-widget"
+        data-product-id="{{ product.id }}"
+        data-name="{{ product.title | escape }}"
+        data-url="{{ shop.url }}{{ product.url }}"
+        {% if product.featured_image %}
+          data-image-url="{{ product.featured_image | image_url: width: 1024 }}"
+        {% endif %}
+        data-description="{{ product.description | strip_html | truncate: 300 | escape }}">
+      </div>
     </div>
   </div>
 </section>
@@ -29,6 +39,7 @@
   "tag": "section",
   "settings": [
     { "type": "text", "id": "heading", "label": "Heading", "default": "Customer Reviews" },
+    { "type": "text", "id": "subheading", "label": "Subheading", "default": "" },
     { "type": "checkbox", "id": "boxed_container", "label": "Boxed container (900px max)", "default": true }
   ],
   "templates": ["product"]


### PR DESCRIPTION
## Summary
- extend the PDP reviews section background so the white canvas spans the full width of the product content column while keeping the widget boxed
- add an editable heading and optional subheading with centered, branded styling for the reviews area
- adjust spacing and typography for better presentation on desktop and mobile

## Testing
- not run (theme-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e655e38410832f95c153f1008c8855