### PR TITLE
Move PDP reviews layout polish into snippet

### DIFF
--- a/sections/product-main-content.liquid
+++ b/sections/product-main-content.liquid
@@ -384,7 +384,11 @@
   </div>
 </div>
 
-{%- render 'product-reviews-fullwidth', boxed_container: section.settings.reviews_boxed_container -%}
+{%- render 'product-reviews-fullwidth',
+  heading: section.settings.reviews_heading,
+  subheading: section.settings.reviews_subheading,
+  boxed_container: section.settings.reviews_boxed_container
+-%}
 {%- render 'footer-minimal-ordering' -%}
 <script type="application/json" data-product-json>{{ product | json }}</script>
 {% if product.handle == 'custom-meals' or product.handle == 'custom-breakfast' %}
@@ -619,6 +623,12 @@
       "id": "reviews_heading",
       "label": "Reviews heading",
       "default": "Customer Reviews"
+    },
+    {
+      "type": "text",
+      "id": "reviews_subheading",
+      "label": "Reviews subheading",
+      "default": ""
     },
     {
       "type": "checkbox",

--- a/sections/product-reviews-fullwidth.liquid
+++ b/sections/product-reviews-fullwidth.liquid
@@ -4,31 +4,21 @@
 {% endcomment %}
 
 <section class="pdp-reviews-fullwidth {% if section.settings.boxed_container %}pdp-reviews--boxed{% endif %}" data-section-type="pdp-reviews-fullwidth">
-  <div class="pdp-reviews__inner">
-    <a id="yotpo-main-widget"></a>
+  <a id="yotpo-main-widget"></a>
 
-    {% if section.settings.heading != blank or section.settings.subheading != blank %}
-      <div class="pdp-reviews__header">
-        {% if section.settings.heading != blank %}
-          <h2 class="pdp-reviews__heading">{{ section.settings.heading }}</h2>
-        {% endif %}
+  {% if section.settings.heading != blank %}
+    <h2 class="pdp-reviews__heading">{{ section.settings.heading }}</h2>
+  {% endif %}
 
-        {% if section.settings.subheading != blank %}
-          <p class="pdp-reviews__subheading">{{ section.settings.subheading }}</p>
-        {% endif %}
-      </div>
-    {% endif %}
-
-    <div class="pdp-reviews__container">
-      <div class="yotpo yotpo-main-widget"
-        data-product-id="{{ product.id }}"
-        data-name="{{ product.title | escape }}"
-        data-url="{{ shop.url }}{{ product.url }}"
-        {% if product.featured_image %}
-          data-image-url="{{ product.featured_image | image_url: width: 1024 }}"
-        {% endif %}
-        data-description="{{ product.description | strip_html | truncate: 300 | escape }}">
-      </div>
+  <div class="pdp-reviews__container">
+    <div class="yotpo yotpo-main-widget"
+      data-product-id="{{ product.id }}"
+      data-name="{{ product.title | escape }}"
+      data-url="{{ shop.url }}{{ product.url }}"
+      {% if product.featured_image %}
+        data-image-url="{{ product.featured_image | image_url: width: 1024 }}"
+      {% endif %}
+      data-description="{{ product.description | strip_html | truncate: 300 | escape }}">
     </div>
   </div>
 </section>
@@ -39,7 +29,6 @@
   "tag": "section",
   "settings": [
     { "type": "text", "id": "heading", "label": "Heading", "default": "Customer Reviews" },
-    { "type": "text", "id": "subheading", "label": "Subheading", "default": "" },
     { "type": "checkbox", "id": "boxed_container", "label": "Boxed container (900px max)", "default": true }
   ],
   "templates": ["product"]

--- a/snippets/product-reviews-fullwidth.liquid
+++ b/snippets/product-reviews-fullwidth.liquid
@@ -1,30 +1,50 @@
 {%- comment -%}
   PDP Reviews snippet used inside product main content.
-  Mirrors the original section markup while avoiding nested sections.
+  Provides the full-width canvas, centered heading, and optional subheading wrapper for the Yotpo widget.
 {%- endcomment -%}
-{%- assign reviews_heading = heading -%}
-{%- if boxed_container == nil -%}
-  {%- assign reviews_boxed_container = true -%}
-{%- else -%}
-  {%- assign reviews_boxed_container = boxed_container -%}
-{%- endif -%}
+{%- liquid
+  assign reviews_heading = heading
+  if reviews_heading == blank and section and section.settings.reviews_heading != blank
+    assign reviews_heading = section.settings.reviews_heading
+  endif
 
-<section class="pdp-reviews-fullwidth{% if reviews_boxed_container %} pdp-reviews--boxed{% endif %}" data-section-type="pdp-reviews-fullwidth" style="background-color: #FFFFFF;">
-  <a id="yotpo-main-widget"></a>
+  assign reviews_subheading = subheading
+  if reviews_subheading == blank and section and section.settings.reviews_subheading != blank
+    assign reviews_subheading = section.settings.reviews_subheading
+  endif
 
-  {%- if reviews_heading != blank -%}
-    <h2 class="pdp-reviews__heading">{{ reviews_heading }}</h2>
-  {%- endif -%}
+  assign reviews_boxed_container = boxed_container
+  if reviews_boxed_container == nil
+    assign reviews_boxed_container = true
+  endif
+-%}
 
-  <div class="pdp-reviews__container">
-    <div class="yotpo yotpo-main-widget"
-      data-product-id="{{ product.id }}"
-      data-name="{{ product.title | escape }}"
-      data-url="{{ shop.url }}{{ product.url }}"
-      {%- if product.featured_image -%}
-        data-image-url="{{ product.featured_image | image_url: width: 1024 }}"
-      {%- endif -%}
-      data-description="{{ product.description | strip_html | truncate: 300 | escape }}">
+<section class="pdp-reviews-fullwidth{% if reviews_boxed_container %} pdp-reviews--boxed{% endif %}" data-section-type="pdp-reviews-fullwidth">
+  <div class="pdp-reviews__inner">
+    <a id="yotpo-main-widget"></a>
+
+    {%- if reviews_heading != blank or reviews_subheading != blank -%}
+      <div class="pdp-reviews__header">
+        {%- if reviews_heading != blank -%}
+          <h2 class="pdp-reviews__heading">{{ reviews_heading }}</h2>
+        {%- endif -%}
+
+        {%- if reviews_subheading != blank -%}
+          <p class="pdp-reviews__subheading">{{ reviews_subheading }}</p>
+        {%- endif -%}
+      </div>
+    {%- endif -%}
+
+    <div class="pdp-reviews__container">
+      <div class="yotpo yotpo-main-widget"
+        data-product-id="{{ product.id }}"
+        data-name="{{ product.title | escape }}"
+        data-url="{{ shop.url }}{{ product.url }}"
+        {%- if product.featured_image -%}
+          data-image-url="{{ product.featured_image | image_url: width: 1024 }}"
+        {%- endif -%}
+        data-description="{{ product.description | strip_html | truncate: 300 | escape }}">
+      </div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- port the PDP reviews header and layout wrapper into the reusable snippet used by the product main content
- expose an optional reviews subheading setting on the product main content section and pass settings through to the snippet
- restore the standalone PDP reviews section to its original minimal markup so it no longer carries the new layout logic

## Testing
- not run (theme-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e657aea6cc832f926a3cbb9a384768