### PR TITLE
Adjust collection grid layout spacing

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -3963,7 +3963,7 @@ product-form-controller.meal-plan-premium-layout .meal-plan-hero-container {
   list-style: none;
   width: 100%;
   justify-items: stretch;
-  padding-block-start: clamp(0.75rem, 2vw, 1.25rem);
+  padding-block-start: clamp(1.25rem, 3vw, 2.25rem);
 }
 
 #CollectionProductGrid .product-grid,
@@ -4034,7 +4034,7 @@ product-form-controller.meal-plan-premium-layout .meal-plan-hero-container {
   #CollectionProductGrid:not(.grid-view--2-col) .product-grid .row,
   .template-search .product-grid,
   .template-search .product-grid .row {
-    grid-template-columns: repeat(3, minmax(18rem, 1fr));
+    grid-template-columns: repeat(3, minmax(19rem, 1fr));
   }
 }
 
@@ -4043,16 +4043,25 @@ product-form-controller.meal-plan-premium-layout .meal-plan-hero-container {
   #CollectionProductGrid:not(.grid-view--2-col) .product-grid .row,
   .template-search .product-grid,
   .template-search .product-grid .row {
-    grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
+    grid-template-columns: repeat(3, minmax(19.5rem, 1fr));
   }
 }
 
-@media (min-width: 96.0625rem) {
+@media (min-width: 96.0625rem) and (max-width: 120rem) {
   #CollectionProductGrid:not(.grid-view--2-col) .product-grid,
   #CollectionProductGrid:not(.grid-view--2-col) .product-grid .row,
   .template-search .product-grid,
   .template-search .product-grid .row {
-    grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+    grid-template-columns: repeat(4, minmax(19.5rem, 1fr));
+  }
+}
+
+@media (min-width: 120.0625rem) {
+  #CollectionProductGrid:not(.grid-view--2-col) .product-grid,
+  #CollectionProductGrid:not(.grid-view--2-col) .product-grid .row,
+  .template-search .product-grid,
+  .template-search .product-grid .row {
+    grid-template-columns: repeat(5, minmax(19.5rem, 1fr));
   }
 }
 


### PR DESCRIPTION
## Summary
- add additional top spacing before the collection product grid
- tune responsive grid breakpoints to favor three columns and cap the widest layouts at five columns

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6827d3d20832fb4329cb76e8f44f3