### PR TITLE
Restore mobile collection grid gutters without shrinking header

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -712,11 +712,16 @@ body.template-suffix--meal-plans .collection-selector__toggle {
     position: fixed !important; top: 0 !important; left: 0 !important;
     width: 90% !important; max-width: 400px !important; height: 100vh !important;
     border: none !important; border-radius: 0 !important; box-shadow: 0 0 20px rgba(0,0,0,0.2) !important;
-    z-index: 9999 !important; transform: translateX(-100%);
-    transition: transform 0.4s cubic-bezier(0.25, 1, 0.5, 1);
-    display: block !important; overflow: hidden !important; pointer-events: auto;
+    z-index: 9999 !important; transform: translateX(-120%);
+    transition: transform 0.4s cubic-bezier(0.25, 1, 0.5, 1), opacity 0.2s ease;
+    display: block !important; overflow: hidden !important; pointer-events: none;
+    opacity: 0; visibility: hidden;
   }
-  .collection-selector[aria-expanded="true"] .collection-selector__menu { transform: translateX(0); }
+  .collection-selector[aria-expanded="true"] .collection-selector__menu {
+    transform: translateX(0);
+    pointer-events: auto;
+    opacity: 1; visibility: visible;
+  }
   .collection-selector__menu-content-wrapper {
     position: relative; width: 100%; height: 100%; overflow: hidden; display: block !important;
   }
@@ -4478,12 +4483,23 @@ body[class*='product-custom-meals'] .cart-drawer__property .ingredient-name {
 
   body.template-collection .collection-page__main,
   body.template-product .collection-page__main {
-    padding: 0 1rem;
     padding-bottom: max(0.5rem, env(safe-area-inset-bottom));
     border-right: none;
     height: auto !important;
     min-height: 0 !important;
     overflow: visible !important;
+  }
+
+  body.template-collection .collection-page__main {
+    padding-inline: 0;
+  }
+
+  body.template-product .collection-page__main {
+    padding-inline: 1rem;
+  }
+
+  body.template-collection #CollectionProductGrid {
+    padding-inline: var(--collection-grid-mobile-gutter, 1rem);
   }
 
   body.template-product .collection-page__layout {


### PR DESCRIPTION
## Summary
- keep the collapsed mobile collection selector completely off canvas so it no longer peeks in from the left edge
- remove the mobile padding on the collection main column while adding localized gutters around the product grid

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e68ad1b12c832f9b38a1b5a550974a