### PR TITLE
Fix mobile width for product main content

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -4495,11 +4495,28 @@ body[class*='product-custom-meals'] .cart-drawer__property .ingredient-name {
   }
 
   body.template-product .collection-page__main {
-    padding-inline: 1rem;
+    /* MOBILE FULL-WIDTH FIX: mirror the collection page gutter removal */
+    padding-inline: 0;
   }
 
   body.template-collection #CollectionProductGrid {
     padding-inline: var(--collection-grid-mobile-gutter, 1rem);
+  }
+
+  body.template-product #CollectionProductGrid {
+    width: 100%;
+  }
+
+  body.template-product #CollectionProductGrid > .product-grid {
+    margin: 0;
+    padding-inline: 0;
+    width: 100%;
+    max-width: none;
+  }
+
+  body.template-product #CollectionProductGrid > .product-grid > .grid__item {
+    width: 100% !important;
+    max-width: none !important;
   }
 
   body.template-product .collection-page__layout {


### PR DESCRIPTION
## Summary
- remove the extra mobile padding on the product page main column so content can span the full viewport
- force the product grid wrapper and item to take the full width on mobile, mirroring the recent collection page fix

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e691825904832f894ae37a63111e86