### PR TITLE
Make Groundhog Day bundle tier links and totals configurable and remove flavor-picker UI

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -5313,15 +5313,3 @@ body.template-page-contact #contact-form .form-control {
   color: var(--color-primary);
   border-color: var(--border-color);
 }
-
-.cart-sidebar__bundle-note,
-.cart-drawer__bundle-note {
-  margin-bottom: 16px;
-  padding: 12px 14px;
-  border-radius: 10px;
-  background: #f7f3ff;
-  border: 1px solid #d7c8ff;
-  color: #4b2a8a;
-  font-size: 0.9rem;
-  font-weight: 600;
-}

--- a/sections/LP-Groundhog-Day-2026.liquid
+++ b/sections/LP-Groundhog-Day-2026.liquid
@@ -8,7 +8,6 @@
   assign s = section.settings
   assign promo_code = s.promo_code | default: "SHADOW31"
   assign end_date = s.end_date_v15 | default: "Feb 3, 2026 03:00:00"
-  assign popcorn_products = s.popcorn_list
 -%}
 
 <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -72,34 +71,12 @@
 .gh-card-v16:hover { transform: translateY(-10px); box-shadow: 0 40px 80px rgba(0,0,0,0.1); }
 .gh-best-value { position: absolute; top: -20px; left: 50%; transform: translateX(-50%); background: var(--l-red); color: #fff; padding: 8px 20px; border-radius: 50px; font-weight: 900; font-size: 0.8rem; z-index: 5; }
 
-.gh-flavor-row-v16 {
-  display: grid; grid-template-columns: 60px 1fr 40px; align-items: center; gap: 15px;
-  padding: 10px; border: 1px solid #eee; border-radius: 12px; margin-bottom: 8px; cursor: pointer; transition: 0.2s;
-}
-.gh-flavor-row-v16.selected { border-color: var(--l-kale); background: var(--l-mint); }
-.gh-flavor-row-v16 img { width: 100%; border-radius: 6px; }
-.gh-check-circle { width: 20px; height: 20px; border: 2px solid #ddd; border-radius: 50%; position: relative; }
-.gh-flavor-row-v16.selected .gh-check-circle { border-color: var(--l-kale); background: var(--l-kale); }
-.gh-flavor-row-v16.selected .gh-check-circle::after { content: '✓'; color: #fff; font-size: 12px; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); }
-
-.gh-atc-v16 {
+.gh-tier-link-v16 {
   background: var(--l-charcoal); color: #fff; border: none; padding: 20px; border-radius: 14px;
-  font-weight: 800; font-size: 1rem; cursor: pointer; margin-top: 20px; transition: 0.3s; opacity: 0.4; pointer-events: none;
+  font-weight: 800; font-size: 1rem; cursor: pointer; margin-top: 20px; transition: 0.3s;
+  text-decoration: none; text-align: center; display: inline-block; width: 100%;
 }
-  .gh-atc-v16.active { opacity: 1; pointer-events: auto; background: var(--l-red); }
-  .gh-atc-v16.loading { cursor: wait; }
-  .gh-card-error {
-    margin-top: 12px;
-    padding: 10px 12px;
-    border-radius: 10px;
-    background: #fff5f5;
-    border: 1px solid #f2b8b8;
-    color: #8b1c1c;
-    font-weight: 600;
-    font-size: 0.85rem;
-    display: none;
-  }
-  .gh-card-error.is-visible { display: block; }
+.gh-tier-link-v16:hover { background: var(--l-red); }
 
 @media (max-width: 900px) {
   .gh-hero-grid-v16, .gh-loop-grid, .gh-hub-inner-v16 { grid-template-columns: 1fr; }
@@ -177,31 +154,17 @@
 
       <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(350px, 1fr)); gap: 30px;">
         {% assign counts = "3,5,10" | split: "," %}
-        {% assign prices = s.tier_prices | split: "," %}
-        {% assign totals = s.tier_totals | split: "," %}
+        {% assign totals = s.bundle_total_3 | append: ',' | append: s.bundle_total_5 | append: ',' | append: s.bundle_total_10 | split: ',' %}
+        {% assign bundle_links = s.bundle_3_link | append: ',' | append: s.bundle_5_link | append: ',' | append: s.bundle_10_link | split: ',' %}
+        {% assign bundle_labels = "Shop 3 Bag Pack,Shop 5 Bag Pack,Shop 10 Pack" | split: "," %}
         {% for count in counts %}
           <div class="gh-card-v16" data-tier="{{ count }}">
             {% if count == "10" %}<div class="gh-best-value">MOST POPULAR</div>{% endif %}
             <div style="margin-bottom: 25px;">
               <span style="font-size: 2.5rem; font-weight: 900; display: block;">{{ count }} Bags</span>
-              <span style="font-size: 1.1rem; color: #666;">${{ prices[forloop.index0] }} / bag</span>
               <div style="margin-top: 15px; background: var(--l-mint); padding: 10px; border-radius: 8px; font-weight: 700; color: var(--l-kale); font-size: 0.85rem; display: inline-block;">
                 ✓ Free Shipping Included
               </div>
-            </div>
-
-            <div style="background: #f9f9f9; padding: 15px; border-radius: 12px; margin-bottom: 20px; font-weight: 800; font-size: 0.8rem; text-align: center;">
-              SELECT <span class="needed-count">{{ count }}</span> FLAVORS: (<span class="current-count">0</span>/{{ count }})
-            </div>
-
-            <div class="gh-flavors-list">
-              {% for prod in popcorn_products %}
-                <div class="gh-flavor-row-v16" data-id="{{ prod.first_available_variant.id }}" data-name="{{ prod.title | replace: 'Protein Popcorn - ', '' }}">
-                  <img src="{{ prod.featured_image | image_url: width: 100 }}">
-                  <span style="font-size: 0.9rem; font-weight: 600;">{{ prod.title | replace: "Protein Popcorn - ", "" }}</span>
-                  <div class="gh-check-circle"></div>
-                </div>
-              {% endfor %}
             </div>
 
             <div style="margin-top: auto; border-top: 1px solid #eee; padding-top: 20px;">
@@ -209,8 +172,7 @@
                 <span style="font-weight: 700; color: #888;">Bundle Total:</span>
                 <span style="font-size: 1.5rem; font-weight: 900;">${{ totals[forloop.index0] }}</span>
               </div>
-              <button class="gh-atc-v16" onclick="addBundleGroup(this)">Add To System</button>
-              <div class="gh-card-error" role="alert" aria-live="polite"></div>
+              <a class="gh-tier-link-v16" href="{{ bundle_links[forloop.index0] }}">{{ bundle_labels[forloop.index0] }}</a>
             </div>
           </div>
         {% endfor %}
@@ -219,107 +181,17 @@
   </section>
 </div>
 
-<script>
-function addBundleGroup(btn) {
-    const card = btn.closest('.gh-card-v16');
-    const tier = parseInt(card.getAttribute('data-tier'));
-    const selected = card.querySelectorAll('.gh-flavor-row-v16.selected');
-    const errorBox = card.querySelector('.gh-card-error');
-    const bundleId = "BNDL-" + Date.now() + "-" + Math.random().toString(36).slice(2, 8);
-    const tierName = card.getAttribute('data-tier') + " Bag Bundle";
-
-    if (selected.length !== tier) {
-        errorBox.textContent = "Please select exactly " + tier + " flavors to continue.";
-        errorBox.classList.add('is-visible');
-        return;
-    }
-
-    let items = [];
-    selected.forEach(row => {
-        items.push({
-            id: parseInt(row.getAttribute('data-id')),
-            quantity: 1,
-            properties: {
-                "_bundle_group": bundleId,
-                "Bundle Tier": tierName,
-                "Bundle Type": "Protein Popcorn"
-            }
-        });
-    });
-
-    errorBox.classList.remove('is-visible');
-    btn.innerText = "ADDING TO CART...";
-    btn.classList.add('loading');
-    btn.disabled = true;
-
-    fetch('/cart/add.js', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ items: items })
-    })
-    .then(res => {
-        if (!res.ok) {
-            return res.json().then(err => Promise.reject(err));
-        }
-        return res.json();
-    })
-    .then(data => {
-        window.location.href = '/cart';
-    })
-    .catch(err => {
-        console.error(err);
-        let message = "Sorry, some flavors are unavailable. Please adjust your selection and try again.";
-        if (err && err.description) {
-            message = err.description;
-        }
-        errorBox.textContent = message;
-        errorBox.classList.add('is-visible');
-        btn.innerText = "TRY AGAIN";
-        btn.classList.remove('loading');
-        btn.disabled = false;
-    });
-}
-
-document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('.gh-card-v16').forEach(card => {
-        const tier = parseInt(card.getAttribute('data-tier'));
-        const atc = card.querySelector('.gh-atc-v16');
-        const currentLabel = card.querySelector('.current-count');
-        const errorBox = card.querySelector('.gh-card-error');
-        let count = 0;
-
-        card.querySelectorAll('.gh-flavor-row-v16').forEach(row => {
-            row.addEventListener('click', () => {
-                if(row.classList.contains('selected')) {
-                    row.classList.remove('selected');
-                    count--;
-                } else {
-                    if(count < tier) {
-                        row.classList.add('selected');
-                        count++;
-                    }
-                }
-                currentLabel.innerText = count;
-                if(count === tier) {
-                    atc.classList.add('active');
-                } else {
-                    atc.classList.remove('active');
-                }
-                errorBox.classList.remove('is-visible');
-            });
-        });
-    });
-});
-</script>
-
 {% schema %}
 {
   "name": "Groundhog Master v16",
   "settings": [
     { "type": "text", "id": "promo_code", "label": "Promo Code", "default": "SHADOW31" },
-    { "type": "product_list", "id": "popcorn_list", "label": "Popcorn Flavors", "limit": 16 },
-    { "type": "text", "id": "tier_prices", "label": "Per Bag Prices (3,5,10)", "default": "10.00,7.50,7.00" },
-    { "type": "text", "id": "tier_totals", "label": "Total Prices (3,5,10)", "default": "30.00,37.50,70.00" },
+    { "type": "text", "id": "bundle_total_3", "label": "Bundle Total (3 Bag)", "default": "29.99" },
+    { "type": "text", "id": "bundle_total_5", "label": "Bundle Total (5 Bag)", "default": "39.99" },
+    { "type": "text", "id": "bundle_total_10", "label": "Bundle Total (10 Bag)", "default": "69.99" },
+    { "type": "url", "id": "bundle_3_link", "label": "3 Bag Bundle Link" },
+    { "type": "url", "id": "bundle_5_link", "label": "5 Bag Bundle Link" },
+    { "type": "url", "id": "bundle_10_link", "label": "10 Bag Bundle Link" },
     { "type": "url", "id": "nav_1_link", "label": "Nav 1 Link" },
     { "type": "url", "id": "nav_2_link", "label": "Nav 2 Link" },
     { "type": "url", "id": "nav_3_link", "label": "Nav 3 Link" }

--- a/snippets/cart-item-list.liquid
+++ b/snippets/cart-item-list.liquid
@@ -21,22 +21,10 @@
     assign class_prefix = 'cart-drawer'
   endif
   assign rc_processed_bundles = '|'  
-  assign has_popcorn_bundle = false
-  for item in cart.items
-    if item.properties._bundle_group != blank and item.properties['Bundle Type'] == 'Protein Popcorn'
-      assign has_popcorn_bundle = true
-      break
-    endif
-  endfor
 -%}
 
 <div class="{{ class_prefix }}__content">
   {% if cart.item_count > 0 %}
-    {%- if has_popcorn_bundle -%}
-      <div class="{{ class_prefix }}__bundle-note" role="note">
-        Bundle pricing requires exactly 3, 5, or 10 popcorn bags. Removing items may remove bundle pricing.
-      </div>
-    {%- endif -%}
     <ul class="{{ class_prefix }}__items cart-items" aria-label="Cart items">
 
       {% for item in cart.items %}
@@ -261,11 +249,6 @@
             assign is_custom_meal = true
           endif
 
-          assign is_popcorn_bundle = false
-          if item.properties._bundle_group != blank and item.properties['Bundle Type'] == 'Protein Popcorn'
-            assign is_popcorn_bundle = true
-          endif
-
           assign product_type_lower = item.product.type | downcase
           assign is_meal_plan = false
           if product_type_lower contains 'meal plan' or item.product.handle contains 'meal-plan'
@@ -338,13 +321,13 @@
             <div class="{{ class_prefix }}__item-meta">
               <div class="{{ class_prefix }}__item-top-row">
                 <div class="{{ class_prefix }}__item-actions">
-                  <div class="{{ class_prefix }}__quantity-selector{% if is_bogo_gift or is_popcorn_bundle %} {{ class_prefix }}__quantity-selector--static{% endif %}">
+                  <div class="{{ class_prefix }}__quantity-selector{% if is_bogo_gift %} {{ class_prefix }}__quantity-selector--static{% endif %}">
                     <button
                       type="button"
                       class="{{ class_prefix }}__quantity-btn"
                       data-action="minus"
                       aria-label="Decrease quantity"
-                      {% if is_bogo_gift or is_popcorn_bundle %}disabled aria-disabled="true"{% endif %}
+                      {% if is_bogo_gift %}disabled aria-disabled="true"{% endif %}
                     >－</button>
                     <input
                       type="number"
@@ -353,14 +336,14 @@
                       min="0"
                       inputmode="numeric"
                       aria-label="Quantity"
-                      {% if is_bogo_gift or is_popcorn_bundle %}readonly disabled{% endif %}
+                      {% if is_bogo_gift %}readonly disabled{% endif %}
                     >
                     <button
                       type="button"
                       class="{{ class_prefix }}__quantity-btn"
                       data-action="plus"
                       aria-label="Increase quantity"
-                      {% if is_bogo_gift or is_popcorn_bundle %}disabled aria-disabled="true"{% endif %}
+                      {% if is_bogo_gift %}disabled aria-disabled="true"{% endif %}
                     >＋</button>
                   </div>
                 </div>


### PR DESCRIPTION
### Motivation
- Make the Groundhog Day landing CTAs configurable so maintainers can point each tier to the correct Recharge bundle product instead of hardcoding product handles. 
- Match displayed bundle pricing to the real PDP prices (5-pack updated to $39.99) and remove per-bag math to avoid awkward calculations. 
- Remove the deprecated flavor-picker and grouped AJAX add flow so we don't reintroduce `_bundle_group` / `Bundle Type` cart locking logic. 

### Description
- Added section settings for `bundle_total_3`, `bundle_total_5`, `bundle_total_10` and URL settings `bundle_3_link`, `bundle_5_link`, `bundle_10_link` and wired the ladder UI to use those values. 
- Removed the per-bag pricing line and replaced it with a single "Bundle Total: $X" that reads from the new bundle total settings. 
- Replaced the old flavor-selection UI and grouped AJAX `addBundleGroup` flow with simple CTAs that link to the configured bundle URLs, and removed the `product_list` / popcorn flavor setting and the related JS. 
- Removed the popcorn bundle detection and bundle-note from `snippets/cart-item-list.liquid` and adjusted quantity selector checks to preserve BOGO gift locking only. 
- Cleaned up the scoped CTA styling (`.gh-tier-link-v16`) and removed the `.cart-sidebar__bundle-note` CSS block. 

### Testing
- No automated tests were executed in this environment; changes were staged and committed successfully with `git commit`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f9dcb9ccc832fa34a42f53f5014f6)